### PR TITLE
Adjusted button to point to the relevant doc anchor

### DIFF
--- a/python/tk_desktop/setup_new_os.py
+++ b/python/tk_desktop/setup_new_os.py
@@ -31,7 +31,7 @@ class SetupNewOS(QtGui.QWidget):
         self.setVisible(False)
 
     def launch_docs(self):
-        url = "https://toolkit.shotgunsoftware.com/entries/93728833"
+        url = "https://toolkit.shotgunsoftware.com/entries/93728833#Multiple%20Operating%20Systems"
         QtGui.QDesktopServices.openUrl(url)
 
     def _on_parent_resized(self):


### PR DESCRIPTION
Previously, the doc button displayed was just pointing to the general 'next steps' docs. Now it points to the actual section that covers the changes necessary.
