### PR TITLE
Fix Windows handle error during update project config.

### DIFF
--- a/python/tk_desktop/update_project_config.py
+++ b/python/tk_desktop/update_project_config.py
@@ -93,7 +93,12 @@ class UpdateProjectConfig(QtGui.QWidget):
 
             # call it
             python_process = subprocess.Popen(
-                args, stderr=subprocess.PIPE, stdout=subprocess.PIPE, startupinfo=startupinfo)
+                args,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                startupinfo=startupinfo
+            )
             (stdout, stderr) = python_process.communicate()
         finally:
             # make sure the wait screen gets hidden


### PR DESCRIPTION
Ticket #27463 - Pass in stdin=subprocess.PIPE when launching subprocess to avoid stdin handle bug on Windows.
