### PR TITLE
For #28028, update desktop to use core login framework

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -124,5 +124,4 @@ requires_core_version: "v0.14.64"
 frameworks:
     - {"name": "tk-framework-qtwidgets", "version": "v1.x.x"}
     - {"name": "tk-framework-shotgunutils", "version": "v2.x.x"}
-    - {"name": "tk-framework-login", "version": "v1.x.x"}
     - {"name": "tk-framework-adminui", "version": "v0.x.x"}

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -93,7 +93,7 @@ class DesktopWindow(SystrayWindow):
         self.ui.apps_button.style().unpolish(self.ui.apps_button)
         self.ui.apps_button.style().polish(self.ui.apps_button)
 
-        interactive_authentication.ui_login()
+        interactive_authentication.ui_authenticate()
         connection = shotgun.get_sg_connection()
 
         engine = sgtk.platform.current_engine()
@@ -105,7 +105,7 @@ class DesktopWindow(SystrayWindow):
 
         # User menu
         ###########################
-        current_user = login.get_current_user()
+        current_user = self._get_current_user()
         thumbnail_url = current_user.get("image")
         if thumbnail_url is not None:
             (_, thumbnail_file) = tempfile.mkstemp(suffix=".jpg")
@@ -503,8 +503,11 @@ class DesktopWindow(SystrayWindow):
         self.update_project_config_widget.show()
         self.project_overlay.hide()
 
+    def _get_current_user(self):
+        return login.get_current_user(sgtk.platform.current_engine().tank)
+
     def __populate_pipeline_configurations_menu(self, pipeline_configurations, selected):
-        user = login.get_current_user()
+        user = self._get_current_user()
 
         primary_pc = None
         extra_pcs = []

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -504,6 +504,10 @@ class DesktopWindow(SystrayWindow):
         self.project_overlay.hide()
 
     def _get_current_user(self):
+        # FIXME: login.get_current_user code introduces a regression where the Shotgun account
+        # associated to the os user will be always be returned insead of the one associated with the
+        # login credentials. Once the core is updated so that login.get_current_user returns the user
+        # currently authenticated as, this regression will disappear.
         return login.get_current_user(sgtk.platform.current_engine().tank)
 
     def __populate_pipeline_configurations_menu(self, pipeline_configurations, selected):

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -93,7 +93,7 @@ class DesktopWindow(SystrayWindow):
         self.ui.apps_button.style().unpolish(self.ui.apps_button)
         self.ui.apps_button.style().polish(self.ui.apps_button)
 
-        interactive_authentication.ui_authenticate()
+        interactive_authentication.ui_authenticate(force_human_user_authentication=True)
         connection = shotgun.get_sg_connection()
 
         engine = sgtk.platform.current_engine()

--- a/python/tk_desktop/project_commands_model.py
+++ b/python/tk_desktop/project_commands_model.py
@@ -264,7 +264,7 @@ class ProjectCommandModel(GroupingModel):
             "event_type": self.APP_LAUNCH_EVENT_TYPE,
             "project": self.__project,
             "meta": {"name": command_name, "group": group_name},
-            "user": login.get_current_user(),
+            "user": login.get_current_user(engine.tank),
         }
 
         # use toolkit connection to get ApiUser permissions for event creation
@@ -315,12 +315,9 @@ class ProjectCommandModel(GroupingModel):
         # and a boolean saying whether the corresponding command has been registered
         self.__recents = {}
 
-        # need to know what login to find events for
-        login = ShotgunLogin.get_instance_for_namespace("tk-desktop").get_login()
-
         # pull down matching invents for the current project for the current user
         filters = [
-            ["user", "is", login],
+            ["user", "is", login.get_current_user(sgtk.platform.current_engine().tank)],
             ["project", "is", self.__project],
             ["event_type", "is", self.APP_LAUNCH_EVENT_TYPE],
         ]

--- a/python/tk_desktop/project_commands_model.py
+++ b/python/tk_desktop/project_commands_model.py
@@ -264,7 +264,7 @@ class ProjectCommandModel(GroupingModel):
             "event_type": self.APP_LAUNCH_EVENT_TYPE,
             "project": self.__project,
             "meta": {"name": command_name, "group": group_name},
-            "user": login.get_current_user(engine.tank),
+            "user": login.get_current_user(engine.sgtk),
         }
 
         # use toolkit connection to get ApiUser permissions for event creation

--- a/python/tk_desktop/project_commands_model.py
+++ b/python/tk_desktop/project_commands_model.py
@@ -16,12 +16,10 @@ from sgtk.platform.qt import QtCore, QtGui
 
 import sgtk
 from sgtk.deploy import util
+from sgtk.util import login
 
 from .grouping_model import GroupingModel
 from .grouping_model import GroupingProxyModel
-
-shotgun_login = sgtk.platform.import_framework("tk-framework-login", "shotgun_login")
-ShotgunLogin = shotgun_login.ShotgunLogin
 
 
 class ProjectCommandProxyModel(GroupingProxyModel):
@@ -256,7 +254,6 @@ class ProjectCommandModel(GroupingModel):
             else:
                 tooltip = item.toolTip()
 
-        login = ShotgunLogin.get_instance_for_namespace("tk-desktop").get_login()
         data = {
             # recent is populated by grouping on description, so it needs
             # to be the same for each event created for a given name, but
@@ -267,7 +264,7 @@ class ProjectCommandModel(GroupingModel):
             "event_type": self.APP_LAUNCH_EVENT_TYPE,
             "project": self.__project,
             "meta": {"name": command_name, "group": group_name},
-            "user": login,
+            "user": login.get_current_user(),
         }
 
         # use toolkit connection to get ApiUser permissions for event creation

--- a/python/tk_desktop/project_model.py
+++ b/python/tk_desktop/project_model.py
@@ -16,7 +16,7 @@ import datetime
 from tank.platform.qt import QtCore, QtGui
 
 import sgtk
-from sgtk.util import login
+from sgtk.util import login, shotgun
 
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 
@@ -250,16 +250,16 @@ class SgProjectModel(ShotgunModel):
         # merge in timestamps from project launch events if they are newer than
         # the last access timestamps from Shotgun
 
+        engine = sgtk.platform.current_engine()
         # pull down matching events for the current user
         filters = [
-            ["user", "is", login.get_current_user()],
+            ["user", "is", login.get_current_user(engine.tank)],
             ["event_type", "is", self.PROJECT_LAUNCH_EVENT_TYPE],
         ]
 
         # execute the Shotgun summarize command
         # get one group per project with a summary of the latest created_at
-        engine = sgtk.platform.current_engine()
-        connection = sgtk.platform.current_engine().shotgun
+        connection = engine.shotgun
 
         start_time = time.time()
         summary = connection.summarize(
@@ -336,7 +336,7 @@ class SgProjectModel(ShotgunModel):
             "event_type": self.PROJECT_LAUNCH_EVENT_TYPE,
             "project": project,
             "meta": {"version": engine.version},
-            "user": login.get_current_user(),
+            "user": login.get_current_user(engine.tank),
         }
 
         start_time = time.time()

--- a/python/tk_desktop/project_model.py
+++ b/python/tk_desktop/project_model.py
@@ -217,7 +217,7 @@ class SgProjectModel(ShotgunModel):
         """ Constructor """
         ShotgunModel.__init__(self, parent, download_thumbs=True)
 
-        self.set_shotgun_connection(shotgun.create_sg_connection())
+        self.set_shotgun_connection(sgtk.platform.current_engine().sgtk.shotgun)
 
         # load up the thumbnail to use when there is none set in Shotgun
         self._missing_thumbnail_project = QtGui.QPixmap(":/tk-desktop/missing_thumbnail_project.png")


### PR DESCRIPTION
- Uses tank.platform.interactive_authentication module for managing login and logout.
- Uses tank.util.login.get_current_user to get the Human User that is logged in.
  - get_current_user code introduces a regression where the Shotgun account associated to the os user
   will be always be returned insead of the one associated with the login credentials. Once the core
   is updated so that get_current_user returns the user currently authenticated as, this regression will
   disappear.