### PR TITLE
For #28769, update desktop view so template project's do not show up.

### DIFF
--- a/python/tk_desktop/project_model.py
+++ b/python/tk_desktop/project_model.py
@@ -230,6 +230,7 @@ class SgProjectModel(ShotgunModel):
         filters = [
             ["name", "is_not", "Template Project"],
             ["archived", "is_not", True],
+            ["is_template", "is_not", True]
         ]
         interesting_fields = [
             "name",

--- a/python/tk_desktop/project_model.py
+++ b/python/tk_desktop/project_model.py
@@ -19,6 +19,7 @@ import sgtk
 
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 shotgun_login = sgtk.platform.import_framework("tk-framework-login", "shotgun_login")
+shotgun_api3 = sgtk.platform.import_framework("tk-framework-login", "shotgun_api3")
 
 ShotgunModel = shotgun_model.ShotgunModel
 ShotgunLogin = shotgun_login.ShotgunLogin
@@ -214,6 +215,22 @@ class SgProjectModel(ShotgunModel):
     thumbnail_updated = QtCore.Signal(QtGui.QStandardItem)
     project_launched = QtCore.Signal()
 
+    _supports_project_templates = None
+
+    @staticmethod
+    def supports_project_templates(connection):
+        # If we haven't checked on the server yet.
+        if SgProjectModel._supports_project_templates is None:
+            try:
+                # Try to read the field's schema.
+                connection.schema_field_read("Project", "is_template")
+                # If worked therefore it exists.
+                SgProjectModel._supports_project_templates = True
+            except shotgun_api3.Fault:
+                # We got a fault, so it doesn't exist.
+                SgProjectModel._supports_project_templates = False
+        return SgProjectModel._supports_project_templates
+
     def __init__(self, parent, overlay_parent_widget):
         """ Constructor """
         ShotgunModel.__init__(self, parent, download_thumbs=True)
@@ -230,8 +247,12 @@ class SgProjectModel(ShotgunModel):
         filters = [
             ["name", "is_not", "Template Project"],
             ["archived", "is_not", True],
-            ["is_template", "is_not", True]
         ]
+        # Templates projects is a Shotgun 6.0 feature, so make sure it exists
+        # on the server before filtering on that value.
+        if SgProjectModel.supports_project_templates(connection):
+            filters.append(["is_template", "is_not", True])
+
         interesting_fields = [
             "name",
             "sg_status",


### PR DESCRIPTION
Reimplemented #28769 since it broke on pre-6.0 sites. We're now validating that the field exists before trying to filter on it.