### PR TITLE
#29165 If interpreter is not found, the "set up project for a new OS" is displayed

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -732,7 +732,7 @@ class DesktopWindow(SystrayWindow):
                         # python not specified for this os, show the setup new os widget
                         engine.log_error("Cannot find interpreter '%s' defined in "
                                          "config file %s. Will show the special "
-                                         "'setup new OS' screen" % (path_to_python, interpreter_config_file))
+                                         "'no python' UI screen" % (path_to_python, interpreter_config_file))
                         self.setup_new_os_widget.show()
                         self.project_overlay.hide()
                         return

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -728,15 +728,14 @@ class DesktopWindow(SystrayWindow):
                         path_to_python = f.read().strip()
                         core_root = current_config_path
 
-                    if not path_to_python:
+                    if not path_to_python or not os.path.exists(path_to_python):
                         # python not specified for this os, show the setup new os widget
+                        engine.log_error("Cannot find interpreter '%s' defined in "
+                                         "config file %s. Will show the special "
+                                         "'setup new OS' screen" % (path_to_python, interpreter_config_file))
                         self.setup_new_os_widget.show()
                         self.project_overlay.hide()
                         return
-                    if not os.path.exists(path_to_python):
-                        raise RuntimeError(
-                            "Cannot find interpreter %s defined in "
-                            "config file %s!" % (path_to_python, interpreter_config_file))
 
                     # found it
                     break

--- a/python/tk_desktop/ui/about_screen.py
+++ b/python/tk_desktop/ui/about_screen.py
@@ -64,7 +64,7 @@ class Ui_AboutScreen(object):
         AboutScreen.setWindowTitle(QtGui.QApplication.translate("AboutScreen", "About Shotgun Desktop", None, QtGui.QApplication.UnicodeUTF8))
         self.header.setText(QtGui.QApplication.translate("AboutScreen", "<b><big>Shotgun Desktop</big></b>", None, QtGui.QApplication.UnicodeUTF8))
         self.body.setText(QtGui.QApplication.translate("AboutScreen", "Body", None, QtGui.QApplication.UnicodeUTF8))
-        self.copyright.setText(QtGui.QApplication.translate("AboutScreen", "Copyright ©2014 Shotgun Software Inc.\n"
+        self.copyright.setText(QtGui.QApplication.translate("AboutScreen", "Copyright ©2015 Shotgun Software Inc.\n"
 "All rights reserved.", None, QtGui.QApplication.UnicodeUTF8))
 
 from . import resources_rc

--- a/python/tk_desktop/ui/setup_new_os.py
+++ b/python/tk_desktop/ui/setup_new_os.py
@@ -11,7 +11,7 @@ from sgtk.platform.qt import QtCore, QtGui
 class Ui_SetupNewOS(object):
     def setupUi(self, SetupNewOS):
         SetupNewOS.setObjectName("SetupNewOS")
-        SetupNewOS.resize(435, 644)
+        SetupNewOS.resize(304, 550)
         self.horizontalLayout = QtGui.QHBoxLayout(SetupNewOS)
         self.horizontalLayout.setObjectName("horizontalLayout")
         spacerItem = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
@@ -68,6 +68,8 @@ class Ui_SetupNewOS(object):
         self.horizontalLayout_3.addItem(spacerItem3)
         self.verticalLayout.addLayout(self.horizontalLayout_3)
         self.label = QtGui.QLabel(SetupNewOS)
+        self.label.setStyleSheet("font-size: 14px;")
+        self.label.setAlignment(QtCore.Qt.AlignCenter)
         self.label.setWordWrap(True)
         self.label.setObjectName("label")
         self.verticalLayout.addWidget(self.label)
@@ -82,8 +84,10 @@ class Ui_SetupNewOS(object):
 
     def retranslateUi(self, SetupNewOS):
         SetupNewOS.setWindowTitle(QtGui.QApplication.translate("SetupNewOS", "Form", None, QtGui.QApplication.UnicodeUTF8))
-        self.text.setText(QtGui.QApplication.translate("SetupNewOS", "Set up project for new operating system", None, QtGui.QApplication.UnicodeUTF8))
+        self.text.setText(QtGui.QApplication.translate("SetupNewOS", "Python not found", None, QtGui.QApplication.UnicodeUTF8))
         self.button.setText(QtGui.QApplication.translate("SetupNewOS", "Learn More", None, QtGui.QApplication.UnicodeUTF8))
-        self.label.setText(QtGui.QApplication.translate("SetupNewOS", "<html><head/><body><p align=\"center\"><span style=\" font-size:16pt;\">The project has not been set up for the current operating system.</span></p><p align=\"center\"><span style=\" font-size:16pt;\">Click to view the docs on how to update your configuration.</span></p></body></html>", None, QtGui.QApplication.UnicodeUTF8))
+        self.label.setText(QtGui.QApplication.translate("SetupNewOS", "You need to configure the location of Python for this project and operating system.\n"
+"\n"
+"Click to view the docs on how to update your configuration.", None, QtGui.QApplication.UnicodeUTF8))
 
 from . import resources_rc

--- a/python/tk_desktop/ui/update_project_config.py
+++ b/python/tk_desktop/ui/update_project_config.py
@@ -71,6 +71,7 @@ class Ui_UpdateProjectConfig(object):
         self.verticalLayout_2.setSpacing(0)
         self.verticalLayout_2.setObjectName("verticalLayout_2")
         self.label = QtGui.QLabel(UpdateProjectConfig)
+        self.label.setStyleSheet("font-size: 14px;")
         self.label.setScaledContents(False)
         self.label.setAlignment(QtCore.Qt.AlignCenter)
         self.label.setWordWrap(True)
@@ -78,6 +79,8 @@ class Ui_UpdateProjectConfig(object):
         self.label.setObjectName("label")
         self.verticalLayout_2.addWidget(self.label)
         self.success = QtGui.QLabel(UpdateProjectConfig)
+        self.success.setStyleSheet("font-size: 14px;")
+        self.success.setAlignment(QtCore.Qt.AlignCenter)
         self.success.setWordWrap(True)
         self.success.setTextInteractionFlags(QtCore.Qt.LinksAccessibleByMouse|QtCore.Qt.TextSelectableByKeyboard|QtCore.Qt.TextSelectableByMouse)
         self.success.setObjectName("success")
@@ -96,7 +99,8 @@ class Ui_UpdateProjectConfig(object):
         UpdateProjectConfig.setWindowTitle(QtGui.QApplication.translate("UpdateProjectConfig", "Form", None, QtGui.QApplication.UnicodeUTF8))
         self.text.setText(QtGui.QApplication.translate("UpdateProjectConfig", "Add Shotgun Desktop", None, QtGui.QApplication.UnicodeUTF8))
         self.button.setText(QtGui.QApplication.translate("UpdateProjectConfig", "Add", None, QtGui.QApplication.UnicodeUTF8))
-        self.label.setText(QtGui.QApplication.translate("UpdateProjectConfig", "<html><head/><body><p align=\"center\"><span style=\" font-size:16pt;\">Click here to upgrade your</span></p><p align=\"center\"><span style=\" font-size:16pt;\">Pipeline Configuration</span></p></body></html>", None, QtGui.QApplication.UnicodeUTF8))
-        self.success.setText(QtGui.QApplication.translate("UpdateProjectConfig", "<html><head/><body><p align=\"center\"><span style=\" font-size:16pt;\">The project has been set up.</span></p>", None, QtGui.QApplication.UnicodeUTF8))
+        self.label.setText(QtGui.QApplication.translate("UpdateProjectConfig", "Click here to upgrade your\n"
+"Pipeline Configuration", None, QtGui.QApplication.UnicodeUTF8))
+        self.success.setText(QtGui.QApplication.translate("UpdateProjectConfig", "The project has been set up.", None, QtGui.QApplication.UnicodeUTF8))
 
 from . import resources_rc

--- a/resources/about_screen.ui
+++ b/resources/about_screen.ui
@@ -113,7 +113,7 @@
       <string notr="true">font-size: 10px;</string>
      </property>
      <property name="text">
-      <string>Copyright ©2014 Shotgun Software Inc.
+      <string>Copyright ©2015 Shotgun Software Inc.
 All rights reserved.</string>
      </property>
      <property name="alignment">

--- a/resources/setup_new_os.ui
+++ b/resources/setup_new_os.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>435</width>
-    <height>644</height>
+    <width>304</width>
+    <height>550</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -86,7 +86,7 @@
         <string notr="true">font-size: 26px;</string>
        </property>
        <property name="text">
-        <string>Set up project for new operating system</string>
+        <string>Python not found</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -153,8 +153,16 @@ QPushButton::disabled {
      </item>
      <item>
       <widget class="QLabel" name="label">
+       <property name="styleSheet">
+        <string notr="true">font-size: 14px;</string>
+       </property>
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:16pt;&quot;&gt;The project has not been set up for the current operating system.&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:16pt;&quot;&gt;Click to view the docs on how to update your configuration.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>You need to configure the location of Python for this project and operating system.
+
+Click to view the docs on how to update your configuration.</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>

--- a/resources/update_project_config.ui
+++ b/resources/update_project_config.ui
@@ -158,8 +158,12 @@ QPushButton::disabled {
        </property>
        <item>
         <widget class="QLabel" name="label">
+         <property name="styleSheet">
+          <string notr="true">font-size: 14px;</string>
+         </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:16pt;&quot;&gt;Click here to upgrade your&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:16pt;&quot;&gt;Pipeline Configuration&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Click here to upgrade your
+Pipeline Configuration</string>
          </property>
          <property name="scaledContents">
           <bool>false</bool>
@@ -177,8 +181,14 @@ QPushButton::disabled {
        </item>
        <item>
         <widget class="QLabel" name="success">
+         <property name="styleSheet">
+          <string notr="true">font-size: 14px;</string>
+         </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:16pt;&quot;&gt;The project has been set up.&lt;/span&gt;&lt;/p&gt;</string>
+          <string>The project has been set up.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>


### PR DESCRIPTION
This change will display the "setup project for new operating system" whenever the python interpreter file is not found. Previously, it would only show if no value had been defined in the interpreter was found (which corresponded to an uninitialized OS). We are now seeding all OSes with default interpreter paths to help make things work out of the box, meaning that the case where there is a blank interpreter file is much less common. Also added more logging around this to help support and debugging.

This change could be confusing if a user has installed desktop in one location and the rest of her/his studio has installed it somewhere else. This user would now be presented with the "set up for a new OS" screen rather than the (much more technical looking) error message that was previously shown.

I personally think this is ok, but I guess we could polish the copy slightly on the custom UI splash page to more accurately capture this case. Curious to hear what @robblau thinks! 