### PR TITLE
For #28904, two factor authentication support in old desktop

### DIFF
--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -334,8 +334,9 @@ class DesktopEngineSiteImplementation(object):
         dm.set_host(site)
         dm.set_login(login)
 
-        # If the connection is session based, reuse the token
-        if connection.config.session_token is not None:
+        # If we have a version of the framework that supports password mangling with the session token,
+        # try to pick the session token from the connection.
+        if hasattr(sl, "mangle_password") and connection.config.session_token is not None:
             # Extract the credentials from the old Shotgun instance and create a
             # ShotgunUser with them. This will cache the session token as well.
             ShotgunAuthenticator().create_session_user(


### PR DESCRIPTION
- Adds support for two factor authentication when using the old installer with the new desktop engine.