### PR TITLE
For #31081, cleanly shutdown websockets server

### DIFF
--- a/hooks/launch_python.py
+++ b/hooks/launch_python.py
@@ -43,7 +43,12 @@ class LaunchPython(Hook):
         # launch, running the bootstrap and passing through the startup data
         args = [project_python, bootstrap, "-d", pickle_data_path, "-u", utilities_module_path]
         self.parent.log_debug("launching %s" % " ".join(["'%s'" % arg for arg in args]))
-        subprocess.Popen(args, startupinfo=startupinfo)
+
+        # Very important to set close_fds otherwise the websocket server file descriptor
+        # will be shared with the child process and it prevent restarting the server
+        # after the process closes.
+        # Solution was found here: http://stackoverflow.com/a/13593715
+        subprocess.Popen(args, startupinfo=startupinfo, close_fds=True)
 
     def path_to_bootstrap(self):
         """

--- a/hooks/post_install.py
+++ b/hooks/post_install.py
@@ -71,7 +71,11 @@ class PostInstall(sgtk.get_hook_baseclass()):
         for i in range(3, 0, -1):
             splash.set_message("Core updated. Restarting desktop in %d seconds..." % i)
             time.sleep(1)
-        subprocess.Popen(sys.argv)
+        # Very important to set close_fds otherwise the websocket server file descriptor
+        # will be shared with the child process and it prevent restarting the server
+        # after the process closes.
+        # Solution was found here: http://stackoverflow.com/a/13593715
+        subprocess.Popen(sys.argv, close_fds=True)
         sys.exit(0)
 
     def execute(self, *args, **kwargs):

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -206,6 +206,10 @@ class DesktopEngineSiteImplementation(object):
         # this engine.
         self.startup_version = kwargs.get("startup_version")
 
+        server = kwargs.get("server")
+        if server:
+            server.get_logger().addHandler(self._engine._handler)
+
         if self.uses_legacy_authentication():
             self._migrate_credentials()
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -426,8 +426,12 @@ class DesktopWindow(SystrayWindow):
         engine.disconnect_app_proxy()
 
         # restart the application
-        subprocess.Popen(sys.argv)
         self.handle_quit_action()
+        # Very important to set close_fds otherwise the websocket server file descriptor
+        # will be shared with the child process and it prevent restarting the server
+        # after the process closes.
+        # Solution was found here: http://stackoverflow.com/a/13593715
+        subprocess.Popen(sys.argv, close_fds=True)
 
     def is_on_top(self):
         return (self.windowFlags() & QtCore.Qt.WindowStaysOnTopHint)


### PR DESCRIPTION
- Launching subprocesses with the close_fds flag to prevent inheriting socket handles, which meant that subprocesses could hold the file descriptor for the port 9000 open.
- Adding desktop server logger to the desktop log