### PR TITLE
Ticket #31606 - Update Desktop to respect project specific debug flag

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -157,9 +157,8 @@ class DesktopEngineProjectImplementation(object):
         self._engine._handler.setFormatter(formatter)
 
     def log(self, level, msg, *args):
-        if self.connected:
-            # If we can log through the proxy, only do that to avoid
-            # duplicate entries in the log file
+        if self.connected and self._engine._logger.isEnabledFor(level):
+            # If we can log through the proxy, only do that to avoid duplicate entries in the log file
             try:
                 self.proxy.call_no_response("proxy_log", level, msg, args)
                 return

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -370,7 +370,8 @@ class DesktopEngineSiteImplementation(object):
         self._engine._logger.log(level, msg, *args)
 
     def proxy_log(self, level, msg, args):
-        self._engine._logger.log(level, "[PROXY] %s" % msg, *args)
+        # Use a high level so that messages we are a proxy for will always be logged
+        self._engine._logger.log(100, "[PROXY %s] %s" % (logging.getLevelName(level), msg), *args)
 
     def get_current_login(self):
         """


### PR DESCRIPTION
Make it so that if the project specific python emits a line from logging the Desktop will show it, even if the message is a debug message and the site config is not in debug mode.  This way the settings at the project level are respected.
