### PR TITLE
#31557 Friendlier Errors on Empty OS Path

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -710,6 +710,9 @@ class DesktopWindow(SystrayWindow):
                         "falling back to primary." % pipeline_configuration_id)
                     pipeline_configuration = primary_pipeline_configuration
 
+            # going to launch the configuration, update the project menu if needed
+            self.__populate_pipeline_configurations_menu(pipeline_configurations, pipeline_configuration)
+
             config_path = pipeline_configuration[path_field]
 
             # Now find out the appropriate python to launch
@@ -771,9 +774,6 @@ class DesktopWindow(SystrayWindow):
                 "\n\n%s\n\nSee the console for more details." % str(error)
             self.project_overlay.show_error_message(message)
             return
-
-        # going to launch the configuration, update the project menu if needed
-        self.__populate_pipeline_configurations_menu(pipeline_configurations, pipeline_configuration)
 
         core_python = os.path.join(core_root, "install", "core", "python")
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -722,6 +722,13 @@ class DesktopWindow(SystrayWindow):
             else:
                 raise RuntimeError("unknown platform: %s" % sys.platform)
 
+            if config_path == None:
+                raise RuntimeError("No path set for %s on the Pipeline "
+                                   "Configuration id %d. Please make sure that "
+                                   "it is set on your Shotgun website." %
+                                   (current_platform,
+                                    pipeline_configuration_id))
+
             current_config_path = config_path
             while True:
                 # First see if we have a local configuration for which interpreter

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -725,7 +725,7 @@ class DesktopWindow(SystrayWindow):
             else:
                 raise RuntimeError("unknown platform: %s" % sys.platform)
 
-            if config_path == None:
+            if config_path is None:
                 raise RuntimeError("No path set for %s on the Pipeline "
                                    "Configuration id %d. Please make sure that "
                                    "it is set on your Shotgun website." %

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -723,16 +723,18 @@ class DesktopWindow(SystrayWindow):
             elif sys.platform.startswith("linux"):
                 current_platform = "Linux"
             else:
-                raise RuntimeError("unknown platform: %s" % sys.platform)
+                raise RuntimeError("Unknown platform: %s." % sys.platform)
 
             if config_path is None:
-                raise RuntimeError("No path set for %s on the Pipeline "
-                                   "Configuration \"%s\" (id %d).\n"
-                                   "Please make sure that it is set on your "
-                                   "Shotgun website." %
-                                   (current_platform,
-                                    pipeline_configuration["code"],
-                                    pipeline_configuration_id))
+                engine.log_error("No path set for %s on the Pipeline "
+                                 "Configuration \"%s\" (id %d)." %
+                                 (current_platform,
+                                  pipeline_configuration["code"],
+                                  pipeline_configuration_id))
+
+                raise RuntimeError("To resolve this, please navigate to this "
+                                   "project in Shotgun\nand check the path for "
+                                   "the Pipeline Configuration.")
 
             current_config_path = config_path
             while True:
@@ -750,7 +752,7 @@ class DesktopWindow(SystrayWindow):
                         # python not specified for this os, show the setup new os widget
                         engine.log_error("Cannot find interpreter '%s' defined in "
                                          "config file %s. Will show the special "
-                                         "'no python' UI screen" % (path_to_python, interpreter_config_file))
+                                         "'no python' UI screen." % (path_to_python, interpreter_config_file))
                         self.setup_new_os_widget.show()
                         self.project_overlay.hide()
                         return
@@ -763,17 +765,23 @@ class DesktopWindow(SystrayWindow):
                     current_config_path, "install", "core", "core_%s.cfg" % current_platform)
 
                 if not os.path.exists(parent_config_file):
+                    engine.log_error("No parent or interpreter found at '%s'."
+                                     % current_config_path)
                     raise RuntimeError(
-                        "invalid configuration, no parent or interpreter "
-                        "found at '%s'" % current_config_path)
+                        "Please make sure that the specified path points to a "
+                        "valid configuration.")
 
                 # Read the path to the parent configuration
                 with open(parent_config_file, "r") as f:
                     current_config_path = f.read().strip()
         except Exception, error:
-            engine.log_exception("Error setting up engine environment")
-            message = "Error setting up engine environment" \
-                "\n\n%s\n\nSee the console for more details." % str(error)
+            engine.log_exception("The Toolkit configuration path has not been "
+                                 "set for your operating system or points to "
+                                 "an invalid configuration.")
+            message = ("The Toolkit configuration path has not been set for "
+                       "your operating system\nor points to an invalid "
+                       "configuration.\n\n%s\n\nFor more details, see the "
+                       "console." % str(error))
             self.project_overlay.show_error_message(message)
             return
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -727,9 +727,11 @@ class DesktopWindow(SystrayWindow):
 
             if config_path is None:
                 raise RuntimeError("No path set for %s on the Pipeline "
-                                   "Configuration id %d. Please make sure that "
-                                   "it is set on your Shotgun website." %
+                                   "Configuration \"%s\" (id %d).\n"
+                                   "Please make sure that it is set on your "
+                                   "Shotgun website." %
                                    (current_platform,
+                                    pipeline_configuration["code"],
                                     pipeline_configuration_id))
 
             current_config_path = config_path

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -732,9 +732,8 @@ class DesktopWindow(SystrayWindow):
                                   pipeline_configuration["code"],
                                   pipeline_configuration_id))
 
-                raise RuntimeError("To resolve this, please navigate to this "
-                                   "project in Shotgun\nand check the path for "
-                                   "the Pipeline Configuration.")
+                raise RuntimeError("The Toolkit configuration path has not\n"
+                                   "been set for your operating system.")
 
             current_config_path = config_path
             while True:
@@ -767,21 +766,18 @@ class DesktopWindow(SystrayWindow):
                 if not os.path.exists(parent_config_file):
                     engine.log_error("No parent or interpreter found at '%s'."
                                      % current_config_path)
-                    raise RuntimeError(
-                        "Please make sure that the specified path points to a "
-                        "valid configuration.")
+                    raise RuntimeError("The Toolkit configuration path points\n"
+                                       "to an invalid configuration.")
 
                 # Read the path to the parent configuration
                 with open(parent_config_file, "r") as f:
                     current_config_path = f.read().strip()
         except Exception, error:
-            engine.log_exception("The Toolkit configuration path has not been "
-                                 "set for your operating system or points to "
-                                 "an invalid configuration.")
-            message = ("The Toolkit configuration path has not been set for "
-                       "your operating system\nor points to an invalid "
-                       "configuration.\n\n%s\n\nFor more details, see the "
-                       "console." % str(error))
+            engine.log_exception(str(error))
+            message = ("%s"
+                       "\n\nTo resolve this, open Shotgun in your browser\n"
+                       "and check the paths for this Pipeline Configuration."
+                       "\n\nFor more details, see the console." % str(error))
             self.project_overlay.show_error_message(message)
             return
 


### PR DESCRIPTION
Two small fixes with this PR:

- Friendlier error message if desktop tries to open a pipeline config that doesn't have a path set for the current OS.
- Allow to change pipeline config even if the current pipeline config fails because of an empty OS path (useful as a dev if e.g. Windows is not set on primary, but it is set on an other pipeline config for testing purposes). This is done by moving the context menu initialization before the code that reads the config.

Here's how master currently handles it:

![screen shot 2015-10-27 at 3 14 56 pm](https://cloud.githubusercontent.com/assets/14185921/10769757/15c41800-7cbe-11e5-96e2-303f6fa4564f.png)

Two things to notice here:

- error message is too technical
- can't change primary config

With this fix:
![screen shot 2015-10-27 at 3 15 49 pm](https://cloud.githubusercontent.com/assets/14185921/10769782/31697e88-7cbe-11e5-9383-221c03fed34d.png)
