### PR TITLE
#31592 Register Tabs Through Config

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -138,7 +138,7 @@ description: "The engine that runs inside the Shotgun Desktop Application"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.16.3"
+requires_core_version: "v0.16.33"
 
 frameworks:
     - {"name": "tk-framework-qtwidgets", "version": "v1.x.x"}

--- a/info.yml
+++ b/info.yml
@@ -18,6 +18,25 @@ configuration:
                      commands that do not match any of the values in the groups
                      setting."
 
+    tabs:
+        type: list
+        description: "Controls what apps will show up as tabs.  This is a list
+                     where each element is a dictionary with two keys:
+                     'app_instance' and 'title'. The app_instance value connects
+                     this entry to a particular app instance defined in the
+                     environment configuration file. The title is the string
+                     displayed to select that tab. The order in which the tabs
+                     appear in this list defines the order in which the tabs are
+                     displayed (first element being the leftmost tab, last
+                     element being the rightmost tab)."
+        allows_empty: True
+        default_value: []
+        values:
+            type: dict
+            items:
+                title: { type: str }
+                app_instance: { type: str }
+
     groups:
         type: list
         description: "A list of dictionaries that define what commands get put

--- a/info.yml
+++ b/info.yml
@@ -21,14 +21,14 @@ configuration:
     tabs:
         type: list
         description: "Controls what apps will show up as tabs.  This is a list
-                     where each element is a dictionary with three keys:
-                     'app_instance' and 'name'. The app_instance value connects
-                     this entry to a particular app instance defined in the
-                     environment configuration file. The name is the panel to
-                     run when the tabs are added to the UI. The order in which
-                     the tabs appear in this list defines the order in which the
-                     tabs are displayed (first element being the leftmost tab,
-                     last element being the rightmost tab)."
+                     where each element is a dictionary with two keys:
+                     'app_instance' and 'name'. The 'app_instance' value
+                     connects this entry to a particular app instance defined in
+                     the environment configuration file. 'name' is the command
+                     to run when the tabs are added to the UI. The order in
+                     which the tabs appear in this list defines the order in
+                     which the tabs are displayed (first element being the
+                     leftmost tab, last element being the rightmost tab)."
         allows_empty: True
         default_value: []
         values:

--- a/info.yml
+++ b/info.yml
@@ -30,7 +30,7 @@ configuration:
                      desktop starts up. If 'name' is '', then all commands from
                      the given app instance are started."
         allows_empty: True
-        default_value: []
+        default_value: [{app_instance: tk-desktop, name: ''}]
         values:
             type: dict
             items:

--- a/info.yml
+++ b/info.yml
@@ -21,20 +21,20 @@ configuration:
     tabs:
         type: list
         description: "Controls what apps will show up as tabs.  This is a list
-                     where each element is a dictionary with two keys:
-                     'app_instance' and 'title'. The app_instance value connects
+                     where each element is a dictionary with three keys:
+                     'app_instance' and 'name'. The app_instance value connects
                      this entry to a particular app instance defined in the
-                     environment configuration file. The title is the string
-                     displayed to select that tab. The order in which the tabs
-                     appear in this list defines the order in which the tabs are
-                     displayed (first element being the leftmost tab, last
-                     element being the rightmost tab)."
+                     environment configuration file. The name is the panel to
+                     run when the tabs are added to the UI. The order in which
+                     the tabs appear in this list defines the order in which the
+                     tabs are displayed (first element being the leftmost tab,
+                     last element being the rightmost tab)."
         allows_empty: True
         default_value: []
         values:
             type: dict
             items:
-                title: { type: str }
+                name: { type: str }
                 app_instance: { type: str }
 
     groups:

--- a/info.yml
+++ b/info.yml
@@ -35,7 +35,7 @@ configuration:
                        {app_instance: '', name: 'Apps'}
                      "
         allows_empty: True
-        default_value: [{app_instance: '', name: 'Apps'}]
+        default_value: [{app_instance: '', name: Apps}]
         values:
             type: dict
             items:

--- a/info.yml
+++ b/info.yml
@@ -28,9 +28,14 @@ configuration:
                      configuration file.
                      The 'name' is the menu name of the command to run when
                      desktop starts up. If 'name' is '', then all commands from
-                     the given app instance are started."
+                     the given app instance are started.
+
+                     To add the 'Apps' tab (which contains the app launcher),
+                     add the following startup command to the list:
+                       {app_instance: '', name: 'Apps'}
+                     "
         allows_empty: True
-        default_value: [{app_instance: tk-desktop, name: ''}]
+        default_value: [{app_instance: '', name: 'Apps'}]
         values:
             type: dict
             items:

--- a/info.yml
+++ b/info.yml
@@ -18,17 +18,17 @@ configuration:
                      commands that do not match any of the values in the groups
                      setting."
 
-    tabs:
+    run_at_startup:
         type: list
-        description: "Controls what apps will show up as tabs.  This is a list
+        description: "Controls what apps will run on startup.  This is a list
                      where each element is a dictionary with two keys:
-                     'app_instance' and 'name'. The 'app_instance' value
-                     connects this entry to a particular app instance defined in
-                     the environment configuration file. 'name' is the command
-                     to run when the tabs are added to the UI. The order in
-                     which the tabs appear in this list defines the order in
-                     which the tabs are displayed (first element being the
-                     leftmost tab, last element being the rightmost tab)."
+                     'app_instance' and 'name'.
+                     The 'app_instance' value connects this entry to a
+                     particular app instance defined in the environment
+                     configuration file.
+                     The 'name' is the menu name of the command to run when
+                     desktop starts up. If 'name' is '', then all commands from
+                     the given app instance are started."
         allows_empty: True
         default_value: []
         values:

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -62,14 +62,13 @@ class DesktopEngineSiteImplementation(object):
         """
         selectors = self._engine.get_setting("run_at_startup", [])
 
-        # "Apps" is currently a builtin command, so we first figure out where it
-        # is (its index) in the selectors:
-        def is_apps_selector(selector):
-            return (selector["app_instance"] == self._engine.instance_name and
-                    (selector["name"] == "" or selector["name"] == "Apps"))
-        apps_index = next((i for i, selector in enumerate(selectors)
-                           if is_apps_selector(selector)),
-                          None)
+        # "Apps" is currently a builtin command, so we take care of it
+        # separately.
+        # We first figure out what is its index in the selectors, or None if it
+        # is not present
+        apps_selector = {"app_instance": "", "name": "Apps"}
+        apps_index = (selectors.index(apps_selector)
+                      if apps_selector in selectors else None)
         # strip the "Apps" tab from the selectors, as we handle it separately
         if apps_index is not None:
             del selectors[apps_index]

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -60,13 +60,14 @@ class DesktopEngineSiteImplementation(object):
         This gives an opportunity for apps to display panels through the
         execution of a command, which will add a tab to Desktop.
         """
-        selectors = self._engine.get_setting("run_at_startup", [])
+        apps_selector = {"app_instance": "", "name": "Apps"}
+
+        selectors = self._engine.get_setting("run_at_startup", [apps_selector])
 
         # "Apps" is currently a builtin command, so we take care of it
         # separately.
         # We first figure out what is its index in the selectors, or None if it
         # is not present
-        apps_selector = {"app_instance": "", "name": "Apps"}
         apps_index = (selectors.index(apps_selector)
                       if apps_selector in selectors else None)
         # strip the "Apps" tab from the selectors, as we handle it separately

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -94,24 +94,28 @@ class DesktopEngineSiteImplementation(object):
         for panel in setting_value:
             panel_name = panel["name"]
             instance_name = panel["app_instance"]
-            instance_panels = panels_by_instance.get(instance_name)
+            instance_panels = panels_by_instance.get(instance_name, [])
 
-            if instance_panels is None:
-                self._engine.log_warning(
-                    "Error reading the '%s' configuration settings\n"
-                    "The requested panel '%s' from app '%s' isn't loaded.\n"
-                    "Please make sure that you have the app installed" % (setting, panel_name, instance_name))
-                continue
 
             #TODO extract function from core
             panel_id = "%s_%s" % (instance_name, panel_name)
             panel_id = re.sub("\W", "_", panel_id)
             panel_id = panel_id.lower()
 
-            for (id, callback) in instance_panels:
-                # add the panel if the name from the settings is '' or the name matches
-                if not panel_name or (panel_id == id):
-                    ret_value.append((instance_name, id, callback))
+            # add the panels if the name of the settings is '' or the name
+            # matches
+            matching_panels = [(instance_name, id, callback)
+                               for (id, callback) in instance_panels
+                               if not panel_name or (panel_id == id)]
+            ret_value.extend(matching_panels)
+
+            # give feedback if no panels were found
+            if not matching_panels:
+                self._engine.log_warning(
+                    "Error reading the '%s' configuration settings\n"
+                    "The requested panel '%s' from app '%s' isn't loaded.\n"
+                    "Please make sure that you have the app installed" %
+                    (setting, panel_name, instance_name))
 
         return ret_value
 

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -52,26 +52,32 @@ class DesktopEngineSiteImplementation(object):
 
     ###########################################################################
     # panel support (displayed as tabs)
-    def _init_tabs(self):
+    def _run_startup_commands(self):
         """
-        Create desktop tabs from the registered application panels, following
-        their specified relative positioning.
+        Runs the commands that are configured to be executed at startup, through
+        the 'run_at_startup' setting in the configuration.
+
+        This gives an opportunity for apps to display panels through the
+        execution of a command, which will add a tab to Desktop.
         """
         # manually register the "Apps" tab for now. Ideally should be an app on
         # its own.
         self.desktop_window._register_apps_tab()
 
-        tabs = self._engine.get_setting("tabs", [])
-        commands = self._engine.get_matching_commands(tabs)
+        selectors = self._engine.get_setting("run_at_startup", [])
+        commands = self._engine.get_matching_commands(selectors)
 
-        for (_,_,panel_callback) in commands:
-            # let the panel show itself through its registered callback
-            panel_callback()
+        for (_,_,command_callback) in commands:
+            # Execute the actual command.
+            # For example, a command could be displaying a panel in order to
+            # display it as a tab in the desktop.
+            command_callback()
 
     def show_panel(self, panel_id, title, bundle, widget_class,
                    *args, **kwargs):
         """
-        Adds an app widget as a tab in the desktop UI.
+        Adds an app widget as a tab in the desktop UI. The tab is placed in the
+        next available tab slot in the desktop, going from left to right.
 
         :param panel_id:     Unique identifier for the panel, as obtained by
                              register_panel().
@@ -322,8 +328,8 @@ class DesktopEngineSiteImplementation(object):
         # initialize System Tray
         self.desktop_window = desktop_window.DesktopWindow()
 
-        # initialize the application tabs
-        self._init_tabs()
+        # run the commands that are configured to be executed at startup
+        self._run_startup_commands()
 
         # make sure we close down our rpc threads
         app.aboutToQuit.connect(self._engine.destroy_engine)


### PR DESCRIPTION
Register tabs straight from the config rather than being automatically registered when added as an app (which was less flexible). For example, registering an application to be shown as a tab in desktop would now look like:

```
tabs:
    - {app_instance: tk-desktop-mytasks, name: ''}
```

This uses the new version of *tk-core*, which provides a `get_matching_commands` function to match the commands that match the tab selectors. Therefore, the core minimum version requirement was bumped up to **v0.16.33**.

Here is a tabs registration test with the results:
![screen shot 2015-11-05 at 4 03 53 pm](https://cloud.githubusercontent.com/assets/1843555/10981679/2d9ae66e-83d7-11e5-8ea0-df5ad5b41762.png)

A couple of things to note:
- **first registered tab** was properly registered as the first *My Tasks* tab. No errors there (it matched any command registered by *tk-desktop-mytasks* because of the empty string name selector `''`).
- **second registered tab** was properly registered as the second *My Tasks* tab. No errors there (it matched the command with the exact `'tk-desktop-mytasks2:My Tasks...'` name).
- **third registered tab** failed to register because `tk-bad-app` is not a loaded app. Warning properly shown in console.
- **fourth registered tab** failed to register because `'badname'` does not match any command registered by `tk-desktop-mytasks-badname` (even though the app was properly loaded). Warning properly shown in console.