### PR TITLE
For #34467, auto focus text box when search is clicked

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -370,6 +370,7 @@ class DesktopWindow(SystrayWindow):
             # do not show the project menu for the time being
             # self.ui.project_button.hide()
             self.ui.search_text.show()
+            self.ui.search_text.setFocus()
             self.ui.search_magnifier.show()
             self.ui.search_button.setIcon(self._search_x_icon)
             self.ui.search_button.setStyleSheet("")


### PR DESCRIPTION
Clicking the search icon will automatically give focus to the text widget right next to it.