### PR TITLE
possibility to use environment variables in share core config files

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -773,6 +773,7 @@ class DesktopWindow(SystrayWindow):
                 # Read the path to the parent configuration
                 with open(parent_config_file, "r") as f:
                     current_config_path = f.read().strip()
+                    current_config_path = os.path.expandvars(current_config_path)
         except Exception, error:
             engine.log_exception(str(error))
             message = ("%s"


### PR DESCRIPTION
~~apparently it breaks browser integration, don't know how to fix it~~
fixed also [here](https://github.com/shotgunsoftware/tk-core/pull/250) and [here](https://github.com/shotgunsoftware/tk-framework-desktopstartup/issues/23)
