### PR TITLE
For #29128: Don't use the event log for tracking recent activity

### DIFF
--- a/python/tk_desktop/project_commands_model.py
+++ b/python/tk_desktop/project_commands_model.py
@@ -329,10 +329,15 @@ class ProjectCommandModel(GroupingModel):
         # one-time lookup for app launches from the event log and use that information to seed
         # the recent app launches in settings.
         engine = sgtk.platform.current_engine()
-        engine.log_debug("No recent apps setting found. Falling back on loading recent app "
+        engine.log_debug("No recent apps settings found. Falling back on loading recent app "
                          "launches from the event log.")
 
-        self.__recents = self.__load_recents_from_event_log()
+        # bypass event log query if flag is set (see #29128)
+        if engine.get_setting("bypass_event_log", False):
+            engine.log_debug("bypass_event_log setting detected. Skipping event log query.")
+            self.__recents = {}
+        else:
+            self.__recents = self.__load_recents_from_event_log()
         self.__store_recents_in_settings()
 
     def __load_recents_from_event_log(self):

--- a/python/tk_desktop/project_model.py
+++ b/python/tk_desktop/project_model.py
@@ -16,7 +16,6 @@ import datetime
 from tank.platform.qt import QtCore, QtGui
 
 import sgtk
-from sgtk.util import login
 
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 
@@ -206,8 +205,6 @@ class SgProjectModel(ShotgunModel):
     """
     This model represents the data which is displayed in the projects list view
     """
-    PROJECT_LAUNCH_EVENT_TYPE = "Toolkit_Desktop_ProjectLaunch"
-
     DISPLAY_NAME_ROLE = QtCore.Qt.UserRole + 101
 
     thumbnail_updated = QtCore.Signal(QtGui.QStandardItem)
@@ -280,114 +277,25 @@ class SgProjectModel(ShotgunModel):
         # and force a refresh of the data from Shotgun
         self._refresh_data()
 
-    def _before_data_processing(self, sg_data_list):
-        # merge in timestamps from project launch events if they are newer than
-        # the last access timestamps from Shotgun
-
-        engine = sgtk.platform.current_engine()
-        # pull down matching events for the current user
-        filters = [
-            ["user", "is", engine.get_current_login()],
-            ["event_type", "is", self.PROJECT_LAUNCH_EVENT_TYPE],
-        ]
-
-        # execute the Shotgun summarize command
-        # get one group per project with a summary of the latest created_at
-        connection = engine.shotgun
-
-        start_time = time.time()
-        summary = connection.summarize(
-            entity_type="EventLogEntry",
-            filters=filters,
-            summary_fields=[{"field": "created_at", "type": "latest"}],
-            grouping=[{"field": "project", "type": "exact", "direction": "asc"}],
-        )
-        end_time = time.time()
-        call_duration = end_time-start_time
-        engine.log_debug("Project Launch events summarized (%.3f s)" % call_duration)
-
-        # parse the results
-        # convert all last accessed timestamps to naive datetime objects in UTC time
-        # this makes sure that the event times and Shotgun times can be directly
-        # compared
-        launches_by_project_id = {}
-        for group in summary["groups"]:
-
-            # ignore empty summaries reported by the Shotgun API
-            # these are on the form
-            # {'group_name': '',
-            #  'group_value': None,
-            #   'summaries': {'created_at': '2014-08-07 12:19:23 UTC'}}
-            if group["group_value"] is None:
-                continue
-
-            # convert the text representation of created_at to a UTC based timetuple
-            text_stamp = group["summaries"]["created_at"]
-            time_stamp = datetime.datetime.strptime(text_stamp, "%Y-%m-%d %H:%M:%S %Z")
-            launches_by_project_id[group["group_value"]["id"]] = time_stamp.utctimetuple()
-
-        for project in sg_data_list:
-            if project["last_accessed_by_current_user"] is None:
-                # never accessed in shotgun
-                if project["id"] in launches_by_project_id:
-                    # but is has been launched from the desktop
-                    launch_date = launches_by_project_id[project["id"]]
-                    # set last accessed on the project in UTC
-                    project["last_accessed_by_current_user"] = \
-                        datetime.datetime.fromtimestamp(time.mktime(launch_date))
-                continue
-
-            # grab the shotgun time as a UTC based timetuple
-            shotgun_date = project["last_accessed_by_current_user"].utctimetuple()
-
-            # set the non-overridden one to avoid timezone issues being
-            # introduced by the shotgun model time conversion
-            project["last_accessed_by_current_user"] = \
-                datetime.datetime.fromtimestamp(time.mktime(shotgun_date))
-
-            # if there are desktop launches for this project
-            if project["id"] in launches_by_project_id:
-                launch_date = launches_by_project_id[project["id"]]
-                if launch_date > shotgun_date:
-                    # desktop launch is newer, swap in the event time
-                    project["last_accessed_by_current_user"] = \
-                        datetime.datetime.fromtimestamp(time.mktime(launch_date))
-
-        return sg_data_list
-
     def update_project_accessed_time(self, project):
         """
-        Set the last accessed time for the given project.
+        Set the current user's last-accessed time for the given project.
 
-        This will update the value in the model and create a tracking event
-        in Shotgun.
+        This will update the value in the model and in Shotgun.
         """
-        # use toolkit connection to get ApiUser permissions for event creation
+        if project is None:
+            return
+
+        # Update Project.last_accessed_by_current_user in Shotgun
         engine = sgtk.platform.current_engine()
-        data = {
-            "description": "Project launch from tk-desktop",
-            "event_type": self.PROJECT_LAUNCH_EVENT_TYPE,
-            "project": project,
-            "meta": {"version": engine.version},
-            "user": engine.get_current_login()
-        }
+        engine.shotgun.update_project_last_accessed(project, engine.get_current_login())
 
-        start_time = time.time()
-        engine.shotgun.create("EventLogEntry", data)
-        end_time = time.time()
-        call_duration = end_time-start_time
-
-        engine.log_debug("Registering project launch event (%.3f s): %s" % (call_duration, data))
-
-        # update the data in the model
+        # Update the data in the model
         item = self.item_from_entity("Project", project["id"])
-        project = item.data(ShotgunModel.SG_DATA_ROLE)
-
-        if project is not None:
-            # set to unix seconds rather than datetime to be compatible with shotgun model
-            utc_now = time.mktime(datetime.datetime.utcnow().utctimetuple())
-            project["last_accessed_by_current_user"] = utc_now
-            item.setData(project, ShotgunModel.SG_DATA_ROLE)
+        # set to unix seconds rather than datetime to be compatible with Shotgun model
+        utc_now_epoch = time.mktime(datetime.datetime.utcnow().utctimetuple())
+        project["last_accessed_by_current_user"] = utc_now_epoch
+        item.setData(project, ShotgunModel.SG_DATA_ROLE)
 
         self.project_launched.emit()
 


### PR DESCRIPTION
Previously we used the event log to help track recent app launches and recently accessed projects per user. This was causing performance issues due to the additional queries required to calculate this information (especially on the event log which can be very slow).

With this change, we now track recent app launches using the [settings module in the Shotgun Utils Framework](http://developer.shotgunsoftware.com/tk-framework-shotgunutils/settings.html). These are tracked for the user on a per-project level and are unique to each machine the user is using. Recently accessed Projects are now solely tracked by the `Project.last_accessed_by_currrent_user` field on the Project in Shotgun. This information is updated whenever the Project is accessed via SG Desktop as well.