### PR TITLE
for #29128: add proxy function to get engine settings for project env

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -86,6 +86,7 @@ class DesktopEngineProjectImplementation(object):
         self.msg_server.register_function(self.trigger_callback, "trigger_callback")
         self.msg_server.register_function(self.signal_disconnect, "signal_disconnect")
         self.msg_server.register_function(self.open_project_locations, "open_project_locations")
+        self.msg_server.register_function(self.get_setting, "get_setting")
 
         self.msg_server.start()
 
@@ -151,6 +152,10 @@ class DesktopEngineProjectImplementation(object):
             exit_code = os.system(cmd)
             if exit_code != 0:
                 self._engine.log_error("Failed to launch '%s'!" % cmd)
+
+    def get_setting(self, setting_name, default_value=None):
+        """ Look up engine setting for current environment """
+        return self._engine.get_setting(setting_name, default_value)
 
     def _initialize_logging(self):
         formatter = logging.Formatter("%(asctime)s [PROJ   %(levelname) -7s] %(name)s - %(message)s")


### PR DESCRIPTION
* Adds a proxy function for getting engine settings from the project environment.
* Uses the existing `parent()` settings interface from `desktop_window` instead of reimplementing settings management. 
* This also changes the way we're storing the settings to be more in line with other project-specific settings like `project_expanded_state`. Instead of storing settings in the project scope, we're storing it in the site scope using the project `id` as an identifier (eg. `project_recent_apps.161`). Combined with the using the `parent()` implementation, this solves the issue where the settings module was using the site environment to determine the project scope - which was incorrect.