### PR TITLE
For #38143 and #38081, pipeline configuration menu fix and setup project fix

### DIFF
--- a/python/tk_desktop/communication_base.py
+++ b/python/tk_desktop/communication_base.py
@@ -34,7 +34,6 @@ class CommunicationBase(object):
         """
         self._log_debug("Shutting down communication channel...")
 
-        self._connected = False
         # Be super careful when closing the proxy, because it can be in an inconsistent state and
         # throw errors.
         if self._proxy is not None:

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -636,6 +636,12 @@ class DesktopWindow(SystrayWindow):
             engine = sgtk.platform.current_engine()
             engine.log_debug("launching app proxy for project: %s" % project)
 
+            # Make sure that not only the previous proxy is not running anymore
+            # but that the UI has been cleared as well.
+            engine = sgtk.platform.current_engine()
+            engine.site_comm.shut_down()
+            self.clear_app_uis()
+
             self.project_overlay.start_spin()
 
             self.current_project = project

--- a/python/tk_desktop/project_communication.py
+++ b/python/tk_desktop/project_communication.py
@@ -46,6 +46,13 @@ class ProjectCommunication(CommunicationBase):
             disconnect_callback()
         self.register_function(wrapper, "signal_disconnect")
 
+    def shut_down(self):
+        """
+        Disconnects from the other process and shuts down the local server.
+        """
+        self._connected = False
+        CommunicationBase.shut_down(self)
+
     def join(self):
         """
         Waits for the message server to shut down.
@@ -61,7 +68,6 @@ class ProjectCommunication(CommunicationBase):
 
     def _signal_disconnect(self):
         self._connected = False
-        self
 
     @property
     def connected(self):


### PR DESCRIPTION
This fixes an issue where the Python process wasn't shut down when switching configurations.
I've simply added code in that will ensure that this is always the case.

I've also ensured that the UI gets cleared, which fixed an old bug where the Setup Project page was overlaid on top on the application icons after a project was configured.

Finally, I found some encapsulation violation between ProjectCommunication and BaseCommunication around the _connected attribute which is owned by the derived class.