### PR TITLE
For #39292, Support transparent Software entity icons

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -134,9 +134,10 @@ description: "The engine that runs inside the Shotgun Desktop Application"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.16.3"
+#requires_core_version: "v0.16.3"
+requires_core_version: "v0.18.54"
 
 frameworks:
     - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}
-    - {"name": "tk-framework-shotgunutils", "version": "v4.x.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.1.x"}
     - {"name": "tk-framework-adminui", "version": "v0.x.x"}

--- a/info.yml
+++ b/info.yml
@@ -134,10 +134,9 @@ description: "The engine that runs inside the Shotgun Desktop Application"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-#requires_core_version: "v0.16.3"
-requires_core_version: "v0.18.54"
+requires_core_version: "v0.16.3"
 
 frameworks:
     - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}
-    - {"name": "tk-framework-shotgunutils", "version": "v5.1.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v4.x.x"}
     - {"name": "tk-framework-adminui", "version": "v0.x.x"}

--- a/info.yml
+++ b/info.yml
@@ -134,9 +134,9 @@ description: "The engine that runs inside the Shotgun Desktop Application"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.16.3"
+requires_core_version: "v0.18.54"
 
 frameworks:
     - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}
-    - {"name": "tk-framework-shotgunutils", "version": "v4.x.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x"}
     - {"name": "tk-framework-adminui", "version": "v0.x.x"}

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -24,7 +24,7 @@ from sgtk.bootstrap import ToolkitManager
 from sgtk import util
 from sgtk.platform import constants
 from tank_vendor import shotgun_authentication as sg_auth
-#from sgtk import TankInvalidInterpreterLocationError
+from sgtk import TankInvalidInterpreterLocationError
 
 from .ui import resources_rc
 from .ui import desktop_window
@@ -764,9 +764,9 @@ class DesktopWindow(SystrayWindow):
             toolkit_manager.progress_callback = report_progress
 
             # Step 2: Retrieves the pipeline configurations that use plugin ids usable by the current user.
-            #pipeline_configurations.extend(
-            #    toolkit_manager.get_pipeline_configurations(project)
-            #)
+            pipeline_configurations.extend(
+                toolkit_manager.get_pipeline_configurations(project)
+            )
 
             setting = "pipeline_configuration_for_project_%d" % project["id"]
             if pipeline_configuration_id is None:
@@ -828,7 +828,7 @@ class DesktopWindow(SystrayWindow):
             # Phase 4: Find the interpreter and launch it.
             try:
                 path_to_python = sgtk.get_python_interpreter_for_config(config_path)
-            except: # TankInvalidInterpreterLocationError:
+            except TankInvalidInterpreterLocationError:
                 engine.log_exception("Problem locating interpreter file:")
                 self.setup_new_os_widget.show()
                 self.project_overlay.hide()

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -24,7 +24,7 @@ from sgtk.bootstrap import ToolkitManager
 from sgtk import util
 from sgtk.platform import constants
 from tank_vendor import shotgun_authentication as sg_auth
-from sgtk import TankInvalidInterpreterLocationError
+#from sgtk import TankInvalidInterpreterLocationError
 
 from .ui import resources_rc
 from .ui import desktop_window
@@ -764,9 +764,9 @@ class DesktopWindow(SystrayWindow):
             toolkit_manager.progress_callback = report_progress
 
             # Step 2: Retrieves the pipeline configurations that use plugin ids usable by the current user.
-            pipeline_configurations.extend(
-                toolkit_manager.get_pipeline_configurations(project)
-            )
+            #pipeline_configurations.extend(
+            #    toolkit_manager.get_pipeline_configurations(project)
+            #)
 
             setting = "pipeline_configuration_for_project_%d" % project["id"]
             if pipeline_configuration_id is None:
@@ -828,7 +828,7 @@ class DesktopWindow(SystrayWindow):
             # Phase 4: Find the interpreter and launch it.
             try:
                 path_to_python = sgtk.get_python_interpreter_for_config(config_path)
-            except TankInvalidInterpreterLocationError:
+            except: # TankInvalidInterpreterLocationError:
                 engine.log_exception("Problem locating interpreter file:")
                 self.setup_new_os_widget.show()
                 self.project_overlay.hide()

--- a/python/tk_desktop/no_apps_installed_overlay.py
+++ b/python/tk_desktop/no_apps_installed_overlay.py
@@ -108,7 +108,8 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
                 engine.logger.warning(
                     "ShotgunDataRetriever is unable to download thumbnail source file. "
                     "Attempting to download thumbnail instead. This issue may be "
-                    "resolved by updating local installations of tk-framework-shotgunutils."
+                    "resolved by updating local installations of tk-framework-shotgunutils "
+                    "and tk-core."
                 )
                 sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail(
                     sg_softwares[i]["image"], engine

--- a/python/tk_desktop/no_apps_installed_overlay.py
+++ b/python/tk_desktop/no_apps_installed_overlay.py
@@ -106,10 +106,11 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
                 # An old version of tk-framework-shotgunutils or tk-core is 
                 # likely in use. Try ShotgunDataRetriever.download_thumbnail() instead.
                 engine.logger.warning(
-                    "ShotgunDataRetriever is unable to download thumbnail source file. "
-                    "Attempting to download thumbnail instead. This issue may be "
-                    "resolved by updating local installations of tk-framework-shotgunutils "
-                    "and tk-core."
+                    "ShotgunDataRetriever is unable to download thumbnail source "
+                    "file due to out-of-date libraries. Attempting to download jpeg "
+                    "thumbnail instead, which does not preserve transparency. This icon "
+                    "will appear opaque. This issue may be resolved by updating local "
+                    "installations of tk-framework-shotgunutils and tk-core."
                 )
                 sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail(
                     sg_softwares[i]["image"], engine

--- a/python/tk_desktop/no_apps_installed_overlay.py
+++ b/python/tk_desktop/no_apps_installed_overlay.py
@@ -94,14 +94,15 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
         icon_row_layout = None
         last_software = len(sg_softwares) - 1
         for i in range(len(sg_softwares)):
-            # Download the thumbnail file from Shotgun.
-            sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail(
-                sg_softwares[i]["image"], engine
+            # Download the thumbnail source file from Shotgun, which preserves
+            # transparency and alpha values.
+            sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
+                sg_softwares[i]["type"], sg_softwares[i]["id"], engine
             )
             if not sg_icon:
                 engine.logger.warning(
-                    "Could not download thumbnail for %s entity [%s]: %s" %
-                    (sg_softwares[i]["type"], sg_softwares[i]["id"], sg_softwares[i]["image"])
+                    "Could not download thumbnail for %s entity [%s]" %
+                    (sg_softwares[i]["type"], sg_softwares[i]["id"])
                 )
                 continue
 
@@ -235,8 +236,8 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
             # entities that do not have any Group or User restrictions.
             sw_filters.extend(user_group_filters)
 
-        # List of Software fields to retrieve.
-        sw_fields = ["image"]
+        # Create a placeholder for the list of Software fields to retrieve.
+        sw_fields = []
 
         # Get the list of matching Software entities
         sg_softwares = engine.shotgun.find(sw_entity, sw_filters, sw_fields)

--- a/python/tk_desktop/no_apps_installed_overlay.py
+++ b/python/tk_desktop/no_apps_installed_overlay.py
@@ -12,7 +12,6 @@ import pprint
 
 import sgtk
 
-from sgtk import TankError
 from sgtk.platform.qt import QtCore
 from sgtk.platform.qt import QtGui
 

--- a/python/tk_desktop/no_apps_installed_overlay.py
+++ b/python/tk_desktop/no_apps_installed_overlay.py
@@ -95,26 +95,11 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
         icon_row_layout = None
         last_software = len(sg_softwares) - 1
         for i in range(len(sg_softwares)):
-            try:
-                # Download the thumbnail source file from Shotgun, which preserves
-                # transparency and alpha values.
-                sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
-                    sg_softwares[i]["type"], sg_softwares[i]["id"], engine
-                )
-
-            except (TankError, AttributeError):
-                # An old version of tk-framework-shotgunutils or tk-core is 
-                # likely in use. Try ShotgunDataRetriever.download_thumbnail() instead.
-                engine.logger.warning(
-                    "ShotgunDataRetriever is unable to download thumbnail source "
-                    "file due to out-of-date libraries. Attempting to download jpeg "
-                    "thumbnail instead, which does not preserve transparency. This icon "
-                    "will appear opaque. This issue may be resolved by updating local "
-                    "installations of tk-framework-shotgunutils and tk-core."
-                )
-                sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail(
-                    sg_softwares[i]["image"], engine
-                )
+            # Download the thumbnail source file from Shotgun, which preserves
+            # transparency and alpha values.
+            sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
+                sg_softwares[i]["type"], sg_softwares[i]["id"], engine
+            )
 
             if not sg_icon:
                 engine.logger.warning(
@@ -253,12 +238,8 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
             # entities that do not have any Group or User restrictions.
             sw_filters.extend(user_group_filters)
 
-        # Retrieve the Software thumbnail image to use as a back up if the
-        # thumbnail source cannot be downloaded.
-        sw_fields = ["image"]
-
         # Get the list of matching Software entities
-        sg_softwares = engine.shotgun.find(sw_entity, sw_filters, sw_fields)
+        sg_softwares = engine.shotgun.find(sw_entity, sw_filters)
         engine.logger.debug("Found [%d] Software entities matching filters: %s" %
             (len(sg_softwares), pprint.pformat(sw_filters))
         )


### PR DESCRIPTION
Updates required to retrieve original source images uploaded for thumbnails. The primary reason for this update was to get the icons associated with Software entities to display with transparency in the NoAppsInstalledOverlay widget. The implementation attempts to handle older versions of tk-core and tk-framework-shotgunutils that may not have this feature implemented.