### PR TITLE
For #39698, desktop installer with bundle cache

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -762,6 +762,9 @@ class DesktopWindow(SystrayWindow):
             toolkit_manager.caching_policy = ToolkitManager.CACHE_FULL
             toolkit_manager.plugin_id = "config.desktop"
             toolkit_manager.base_configuration = "sgtk:descriptor:app_store?name=tk-config-basic"
+            toolkit_manager.bundle_cache_fallback_paths.extend(
+                engine.sgtk.bundle_cache_fallback_paths
+            )
 
             # FIXME: This needs to be replaced when we implement proper progress reporting during
             # startup.

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -766,13 +766,6 @@ class DesktopWindow(SystrayWindow):
                 engine.sgtk.bundle_cache_fallback_paths
             )
 
-            # FIXME: This needs to be replaced when we implement proper progress reporting during
-            # startup.
-            def report_progress(percentage, message):
-                print percentage, message
-
-            toolkit_manager.progress_callback = report_progress
-
             # Step 2: Retrieves the pipeline configurations that use plugin ids usable by the current user.
             pipeline_configurations.extend(
                 toolkit_manager.get_pipeline_configurations(project)


### PR DESCRIPTION
Pushes the bundle cache from the site config into the project's.