### PR TITLE
For #38926, boostrap into project

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -596,6 +596,18 @@ class DesktopWindow(SystrayWindow):
         self.project_overlay.hide()
 
     def __populate_pipeline_configurations_menu(self, pipeline_configurations, selected):
+        """
+        This will populate the menu with all the pipeline configurations.
+
+            - It will only be built if two or more configurations are available.
+            - Primaries goes first, then everything else is alphabetical.
+            - If two primaries have the same name, the lowest id comes first.
+            - If more than two pipelines have the same name, their id is suffixed between paratheses.
+
+        :param list pipeline_configurations: List of pipeline configurations link.
+        :param id selected: Id of the pipeline that is currently selected. The selected pipeline
+            will have a marked checked box next to its name.
+        """
 
         engine = sgtk.platform.current_engine()
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -901,10 +901,12 @@ class DesktopWindow(SystrayWindow):
                 toolkit_manager.get_pipeline_configurations(project)
             )
 
-            log.debug("The following pipeline configurations for this project have been found")
+            log.debug("The following pipeline configurations for this project have been found:")
             log.debug(pprint.pformat(pipeline_configurations))
 
-            pipeline_configuration_to_load = self._pick_pipeline(pipeline_configurations, requested_pipeline_id)
+            pipeline_configuration_to_load = self._pick_pipeline(
+                pipeline_configurations, requested_pipeline_id, project
+            )
 
             # going to launch the configuration, update the project menu if needed
             self.__populate_pipeline_configurations_menu(pipeline_configurations, pipeline_configuration_to_load)
@@ -989,10 +991,12 @@ class DesktopWindow(SystrayWindow):
 
             # If there's a primary available, fall back to that.
             if primary_pipeline_configuration:
-                log.warning("Pipeline configuration id %s was not found, falling back to primary.")
+                log.warning(
+                    "Pipeline configuration id %s was not found, falling back to primary.", requested_pipeline_id
+                )
                 pipeline_configuration_to_load = primary_pipeline_configuration
             else:
-                log.warning("Pipeline configuration id %s was not found.")
+                log.warning("Pipeline configuration id %s was not found.", requested_pipeline_id)
 
         if pipeline_configuration_to_load is None:
             log.debug("Updating %s to None.")

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -660,11 +660,11 @@ class DesktopWindow(SystrayWindow):
             for pc in pc_group:
                 # If there are more than one pipeline in the group, we'll suffix the pipeline id.
                 if len(pc_group) > 1:
-                    primary_pc_name = "%s (%d)" % (pc_name, pc["id"])
+                    unique_pc_name = "%s (%d)" % (pc_name, pc["id"])
                 else:
-                    primary_pc_name = pc_name
+                    unique_pc_name = pc_name
 
-                action = self.project_menu.addAction(primary_pc_name)
+                action = self.project_menu.addAction(unique_pc_name)
                 action.setCheckable(True)
                 action.setProperty("project_configuration_id", pc["id"])
 
@@ -672,7 +672,7 @@ class DesktopWindow(SystrayWindow):
                 # menu and update the configuration name widget.
                 if selected["id"] == pc["id"]:
                     action.setChecked(True)
-                    self.ui.configuration_name.setText(primary_pc_name)
+                    self.ui.configuration_name.setText(unique_pc_name)
 
                     # If the pipeline is a primary and there are multiple of these, advertise which
                     # one we are using. Advertise if it isn't a primary as well.


### PR DESCRIPTION
Since more than two pipelines can have the same name, we suffix them with their id when that happens. Does also various bugfixes.

Here's what it looks like in action.
<img width="556" alt="screen shot 2017-02-03 at 23 13 56" src="https://cloud.githubusercontent.com/assets/8126447/22615623/80e8590e-ea66-11e6-8e74-a6d522fc24e4.png">

I don't really like using the id when two things are named the same, but at least it is consistent with other areas in Shotgun like the Shotgun Model.  Ideally we should add a tooltip with the string of the descriptor in the menu or put the descriptor itself inside the parantheses.