### PR TITLE
#40549, Support 'group' and 'group_default' command properties

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -119,7 +119,7 @@ class DesktopEngineProjectImplementation(object):
             self.__callback_map[("__commands", name)] = command_info["callback"]
             # pull out needed values since this needs to be pickleable
             gui_properties = {}
-            for prop in ["type", "icon", "title", "description"]:
+            for prop in ["type", "icon", "title", "description", "group", "group_default"]:
                 if prop in command_info["properties"]:
                     gui_properties[prop] = command_info["properties"][prop]
             # evaluate groups on the app proxy side

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -109,9 +109,15 @@ class DesktopEngineSiteImplementation(object):
         command_type = properties.get("type")
         command_icon = properties.get("icon")
         command_tooltip = properties.get("description")
+        command_group = properties.get("group")
+        command_is_group_default = properties.get("group_default")
+        if not command_group:
+            # If no group has been specified,then this command is automatically
+            # the group default.
+            command_is_group_default = True
 
         icon = None
-        if command_icon is not None:
+        if command_icon is not None and command_is_group_default:
             if os.path.exists(command_icon):
                 icon = QtGui.QIcon(command_icon)
             else:
@@ -146,6 +152,8 @@ class DesktopEngineSiteImplementation(object):
             # the display name of the command
             menu_name = None
             button_name = title
+            found_collapse_match = False
+
             for collapse_rule in self._collapse_rules:
                 template = DisplayNameTemplate(collapse_rule["match"])
                 match = template.match(title)
@@ -156,7 +164,12 @@ class DesktopEngineSiteImplementation(object):
                     else:
                         menu_name = string.Template(collapse_rule["menu_label"]).safe_substitute(match)
                     button_name = string.Template(collapse_rule["button_label"]).safe_substitute(match)
+                    found_collapse_match = True
                     break
+
+            if not found_collapse_match and command_group:
+                button_name = command_group
+                menu_name = title
 
             self.desktop_window.add_project_command(
                 name, button_name, menu_name, icon, command_tooltip, groups

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -118,6 +118,8 @@ class DesktopEngineSiteImplementation(object):
 
         icon = None
         if command_icon is not None and command_is_group_default:
+            # Only register an icon for the command if it exists and the command
+            # is the default one for the group.
             if os.path.exists(command_icon):
                 icon = QtGui.QIcon(command_icon)
             else:
@@ -154,6 +156,8 @@ class DesktopEngineSiteImplementation(object):
             button_name = title
             found_collapse_match = False
 
+            # First check for collapse rules specified for this title in the desktop
+            # configuration. These take precedence over the group property.
             for collapse_rule in self._collapse_rules:
                 template = DisplayNameTemplate(collapse_rule["match"])
                 match = template.match(title)
@@ -167,6 +171,8 @@ class DesktopEngineSiteImplementation(object):
                     found_collapse_match = True
                     break
 
+            # If no collapse rules were found for this title, and the group property is
+            # not empty, treat the specified group as if it were a collapse rule.
             if not found_collapse_match and command_group:
                 button_name = command_group
                 menu_name = title


### PR DESCRIPTION
If no collapse rules have been determined for a command, check for input `group` and `group_default` properties. If present, these will be treated the same as collapse rules. The current implementation does not actually support the `group_default` property, as this is determined at a much lower level by the project_commands_model.