### PR TITLE
40549 improved grouping support

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -119,7 +119,7 @@ class DesktopEngineProjectImplementation(object):
             self.__callback_map[("__commands", name)] = command_info["callback"]
             # pull out needed values since this needs to be pickleable
             gui_properties = {}
-            for prop in ["type", "icon", "title", "description"]:
+            for prop in ["type", "icon", "title", "description", "group", "group_default"]:
                 if prop in command_info["properties"]:
                     gui_properties[prop] = command_info["properties"][prop]
             # evaluate groups on the app proxy side

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -109,9 +109,15 @@ class DesktopEngineSiteImplementation(object):
         command_type = properties.get("type")
         command_icon = properties.get("icon")
         command_tooltip = properties.get("description")
+        command_group = properties.get("group")
+        command_is_group_default = properties.get("group_default")
+        if not command_group:
+            # If no group has been specified,then this command is automatically
+            # the group default.
+            command_is_group_default = True
 
         icon = None
-        if command_icon is not None:
+        if command_icon is not None and command_is_group_default:
             if os.path.exists(command_icon):
                 icon = QtGui.QIcon(command_icon)
             else:
@@ -146,6 +152,8 @@ class DesktopEngineSiteImplementation(object):
             # the display name of the command
             menu_name = None
             button_name = title
+            found_collapse_match = False
+
             for collapse_rule in self._collapse_rules:
                 template = DisplayNameTemplate(collapse_rule["match"])
                 match = template.match(title)
@@ -156,7 +164,12 @@ class DesktopEngineSiteImplementation(object):
                     else:
                         menu_name = string.Template(collapse_rule["menu_label"]).safe_substitute(match)
                     button_name = string.Template(collapse_rule["button_label"]).safe_substitute(match)
+                    found_collapse_match = True
                     break
+
+            if not found_collapse_match and command_group:
+                button_name = command_group
+                menu_name = title
 
             self.desktop_window.add_project_command(
                 name, button_name, menu_name, icon, command_tooltip, groups

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -110,16 +110,11 @@ class DesktopEngineSiteImplementation(object):
         command_icon = properties.get("icon")
         command_tooltip = properties.get("description")
         command_group = properties.get("group")
-        command_is_group_default = properties.get("group_default")
-        if not command_group:
-            # If no group has been specified,then this command is automatically
-            # the group default.
-            command_is_group_default = True
+        command_is_menu_default = properties.get("group_default") or False
 
         icon = None
-        if command_icon is not None and command_is_group_default:
-            # Only register an icon for the command if it exists and the command
-            # is the default one for the group.
+        if command_icon is not None:
+            # Only register an icon for the command if it exists.
             if os.path.exists(command_icon):
                 icon = QtGui.QIcon(command_icon)
             else:
@@ -178,7 +173,7 @@ class DesktopEngineSiteImplementation(object):
                 menu_name = title
 
             self.desktop_window.add_project_command(
-                name, button_name, menu_name, icon, command_tooltip, groups
+                name, button_name, menu_name, icon, command_tooltip, groups, command_is_menu_default
             )
 
     def project_commands_finished(self):

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -118,6 +118,8 @@ class DesktopEngineSiteImplementation(object):
 
         icon = None
         if command_icon is not None and command_is_group_default:
+            # Only register an icon for the command if it exists and the command
+            # is the default one for the group.
             if os.path.exists(command_icon):
                 icon = QtGui.QIcon(command_icon)
             else:
@@ -154,6 +156,8 @@ class DesktopEngineSiteImplementation(object):
             button_name = title
             found_collapse_match = False
 
+            # First check for collapse rules specified for this title in the desktop
+            # configuration. These take precedence over the group property.
             for collapse_rule in self._collapse_rules:
                 template = DisplayNameTemplate(collapse_rule["match"])
                 match = template.match(title)
@@ -167,6 +171,8 @@ class DesktopEngineSiteImplementation(object):
                     found_collapse_match = True
                     break
 
+            # If no collapse rules were found for this title, and the group property is
+            # not empty, treat the specified group as if it were a collapse rule.
             if not found_collapse_match and command_group:
                 button_name = command_group
                 menu_name = title

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -173,7 +173,13 @@ class DesktopEngineSiteImplementation(object):
                 menu_name = title
 
             self.desktop_window.add_project_command(
-                name, button_name, menu_name, icon, command_tooltip, groups, command_is_menu_default
+                name,
+                button_name,
+                menu_name,
+                icon,
+                command_tooltip,
+                groups,
+                command_is_menu_default
             )
 
     def project_commands_finished(self):

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -526,6 +526,20 @@ class DesktopWindow(SystrayWindow):
     def add_project_command(
             self, name, button_name, menu_name, icon, command_tooltip, groups, is_menu_default
         ):
+        """
+        Add a button command to the Project dialog. Keeps a running total of how
+        many commands were added. If no commands are added for the Project, the
+        "We couldn't find anything to launch" overlay is displayed.
+
+        :param str name: The name of the command used for internal tracking
+        :param str button_name: The label for the command button.
+        :param str menu_name: The label for the command button's drop-down menu item.
+        :param QtGui.QIcon icon: The icon to display for the command button and RECENT item.
+        :param str command_tooltip: A brief summary of what this command does.
+        :param list groups: The list of Desktop folder groups this command should appear in.
+        :param bool is_menu_default: If this command is a menu item, indicate whether it should
+                                     also be run by the command button.
+        """
         self._project_command_model.add_command(
             name, button_name, menu_name, icon, command_tooltip, groups, is_menu_default
         )

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -517,10 +517,10 @@ class DesktopWindow(SystrayWindow):
         self.project_menu.insertAction(self.__pipeline_configuration_separator, action)
 
     def add_project_command(
-            self, name, button_name, menu_name, icon, command_tooltip, groups
-    ):
+            self, name, button_name, menu_name, icon, command_tooltip, groups, is_menu_default
+        ):
         self._project_command_model.add_command(
-            name, button_name, menu_name, icon, command_tooltip, groups
+            name, button_name, menu_name, icon, command_tooltip, groups, is_menu_default
         )
         self._project_command_proxy.invalidate()
         self._project_command_count += 1

--- a/python/tk_desktop/project_commands_model.py
+++ b/python/tk_desktop/project_commands_model.py
@@ -112,6 +112,7 @@ class ProjectCommandModel(GroupingModel):
     MENU_NAME_ROLE = QtCore.Qt.UserRole + 2
     COMMAND_ROLE = QtCore.Qt.UserRole + 3
     LAST_LAUNCH_ROLE = QtCore.Qt.UserRole + 4
+    IS_MENU_DEFAULT_ROLE = QtCore.Qt.UserRole + 5
 
     # signal emitted when a command is triggered
     # arguments are the group and the command_name of the triggered command
@@ -139,7 +140,7 @@ class ProjectCommandModel(GroupingModel):
             self.set_group_rank(self.RECENT_GROUP_NAME, 0)
             self.__load_recents()
 
-    def add_command(self, name, button_name, menu_name, icon, command_tooltip, groups):
+    def add_command(self, name, button_name, menu_name, icon, command_tooltip, groups, is_menu_default=False):
         if self.show_recents and name in self.__recents and not self.__recents[name]["added"]:
             item = QtGui.QStandardItem()
             item.setData(button_name, self.BUTTON_NAME_ROLE)
@@ -186,6 +187,7 @@ class ProjectCommandModel(GroupingModel):
                 menu_item.setData(button_name, self.BUTTON_NAME_ROLE)
                 menu_item.setData(menu_name, self.MENU_NAME_ROLE)
                 menu_item.setData(name, self.COMMAND_ROLE)
+                menu_item.setData(is_menu_default, self.IS_MENU_DEFAULT_ROLE)
                 menu_item.setToolTip(command_tooltip)
                 if icon is not None:
                     menu_item.setIcon(icon)
@@ -193,15 +195,33 @@ class ProjectCommandModel(GroupingModel):
 
     @classmethod
     def get_item_children_in_order(cls, item):
+        """
+        Sort the item's children in reverse 'version' order based on the menu name
+        of the item. Item children whose IS_MENU_DEFAULT_ROLE data value is True
+        will be prepended to the list.
+
+        :param QtGui.QStandardItem item: Input project button to sort child menu items for.
+        :returns: List of sorted menu items
+        """
+        # Theoretically, there should only be one "default" child in the list of item
+        # children, but since this is a human configurable value, there may 'accidentally'
+        # be more. Rather than raising an error, attempt to handle this case gracefully
+        # by keeping track of default and non-default children separately. Sort each
+        # list in reverse version number order, then add them together to construct
+        # the list of ordered item children to return.
+        default_children = []
+        other_children = []
         i = 0
-        children = []
         while True:
             child = item.child(i, 0)
             i += 1
             if child is None:
                 break
 
-            children.append(child)
+            if child.data(cls.IS_MENU_DEFAULT_ROLE):
+                default_children.append(child)
+            else:
+                other_children.append(child)
 
         # sort children in reverse version order
         def child_cmp(left, right):
@@ -212,8 +232,14 @@ class ProjectCommandModel(GroupingModel):
             if util.is_version_older(left_version, right_version):
                 return 1
             return 0
-        children.sort(cmp=child_cmp)
-        return children
+
+        # No need to sort lists if they are empty.
+        if other_children:
+            other_children.sort(cmp=child_cmp)
+        if default_children:
+            default_children.sort(cmp=child_cmp)
+
+        return (default_children + other_children)
 
     def _handle_command_triggered(self, item, command_name=None, button_name=None,
                                   menu_name=None, icon=None, tooltip=None):


### PR DESCRIPTION
Implementation to support the `group_default` property value passed into the `engine.register_command()` method.  Also fixes an issue where icons were not being loaded for non-default commands in the RECENTS group.