### PR TITLE
For #36439, site and project desktop use same credentials

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -817,6 +817,10 @@ class DesktopWindow(SystrayWindow):
         # startup server pipe to listen
         engine.startup_rpc()
 
+        # Make sure the credentials are refreshed so the background process
+        # has no problem launching.
+        engine.refresh_user_credentials()
+
         # pickle up the info needed to bootstrap the project python
         desktop_data = {
             "core_python_path": core_python,
@@ -825,7 +829,10 @@ class DesktopWindow(SystrayWindow):
             "proxy_data": {
                 "proxy_pipe": engine.site_comm.server_pipe,
                 "proxy_auth": engine.site_comm.server_authkey
-            }
+            },
+            "current_user": sgtk.authentication.serialize_user(
+                sgtk.get_authenticated_user()
+            )
         }
         (_, pickle_data_file) = tempfile.mkstemp(suffix='.pkl')
         pickle.dump(desktop_data, open(pickle_data_file, "wb"))
@@ -839,10 +846,6 @@ class DesktopWindow(SystrayWindow):
 
         # Check if the pipeline configuration is login based.
         engine.check_login_based(core_root)
-        # Make sure the credentials are refreshed so the background process
-        # has no problem launching.
-        engine.refresh_user_credentials()
-
         # Ticket 26741: Avoid having odd DLL loading issues on windows
         self._push_dll_state()
 

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -35,12 +35,12 @@ def start_engine(data):
         current_user = ShotgunAuthenticator(sgtk.util.CoreDefaultsManager()).get_default_user()
 
         # If we found no user using the authenticator, we need to use the credentials that
-        # came through the data file.
+        # came through the environment variable.
         # Also, if the credentials are user-based, we need to disregard what we got and use
-        # the credentials from the data file. This is required to solve any issues
+        # the credentials from the environment variable. This is required to solve any issues
         # arising from the changes to the session cache changing place in core 0.18.
         if not current_user or current_user.login:
-            current_user = deserialize_user(data["current_user"])
+            current_user = deserialize_user(os.environ["SHOTGUN_DESKTOP_CURRENT_USER"])
         else:
             # This happens when the user retrieved from the project's core is a script.
             # In that case, we use the script user and disregard who is the current


### PR DESCRIPTION
Passes down the credentials from the site desktop to the project desktop with an environment variable. The ticket originally suggested using the `TANK_CONTEXT` environment variable, but using a separate environment was used instead in order to both reduce the number of changes required to make this fix work as well as ensuring there wouldn't be some weird side-effects in we ended up not using the authenticated user from the context. This would have happened on projects that used a script to authenticate.