### PR TITLE
Fix python window appears when launching some apps from SG Desktop

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -244,6 +244,7 @@ class DesktopEngine(Engine):
                     d.show()
                     d.activateWindow()
                     d.raise_()
+                    d.close()
                     d.deleteLater()
                     self._requires_visibility_hack = False
 


### PR DESCRIPTION
This fixes an issue where the Shotgun Desktop on certain computers will show an empty dialog the first time an app in launched.