### PR TITLE
For #41026, Polish UX when using a pre-zero-config Shotgun site

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -786,20 +786,6 @@ class DesktopWindow(SystrayWindow):
         """
         return pc["name"] == constants.PRIMARY_PIPELINE_CONFIG_NAME
 
-    def _get_server_version(self, connection):
-        """
-        Retrieves the server version from the connection.
-
-        :param connection: Connection we want the server version from.
-
-        :returns: Tuple of (major, minor) versions.
-        """
-        sg_major_ver = connection.server_info["version"][0]
-        sg_minor_ver = connection.server_info["version"][1]
-        sg_patch_ver = connection.server_info["version"][2]
-
-        return sg_major_ver, sg_minor_ver, sg_patch_ver
-
     def __launch_app_proxy_for_project(self, project, requested_pipeline_configuration_id=None):
         try:
             engine = sgtk.platform.current_engine()
@@ -863,7 +849,7 @@ class DesktopWindow(SystrayWindow):
             # 'Advanced project setup...' menu item.
             if not pipeline_configurations:
                 # If we have the new Shotgun that supports zero config, add the setup project entry in the menu
-                if self._get_server_version(engine.shotgun) >= (7, 1, 0):
+                if engine.shotgun.server_info >= (7, 1, 0):
                     self.ui.actionAdvanced_Project_Setup.setVisible(True)
                 else:
                     # Otherwise hide the entry and provide the same old experience as before and quit, as we can't

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -871,6 +871,7 @@ class DesktopWindow(SystrayWindow):
                     self.ui.actionAdvanced_Project_Setup.setVisible(False)
                     self.setup_project_widget.project = project
                     self.setup_project_widget.show()
+                    # Stop here, we don't want to launch Python at this point.
                     return
             else:
                 self.ui.actionAdvanced_Project_Setup.setVisible(False)


### PR DESCRIPTION
This restores the UX from the currently released version of tk-desktop for Shotgun sites that don't support zero-config.