### PR TITLE
For #42691, expired credentials fix.

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -639,8 +639,15 @@ class DesktopWindow(SystrayWindow):
                 )
                 new_site = None
 
-            self.activate()
             dialog = BrowserIntegrationUserSwitchDialog(msg, self)
+
+            # The following applies to macOS only and has no side-effect on other plaforms.
+            # If the dialog is pinned, it means it is also in background. We'll bring the app to the foreground
+            # so keyboard focus is granted automatically to the BrowserIntegrationUserSwitchDialog instead
+            # of being unfocussed.
+            if self.is_pinned() and osutils:
+                osutils.make_app_foreground()
+
             dialog.exec_()
 
             if dialog.result() == dialog.RESTART:


### PR DESCRIPTION
When the shotgun desktop is in the background on macos it can't receive keystrokes. Make sure that when the app gains focus (click on the systray icon, the login screen if credentials are out of date or when the "switch user or restart" dialogs appear) it is also brought into foreground.