### PR TITLE
For #41813, usage stats for Shotgun Desktop

### DIFF
--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -212,6 +212,14 @@ class DesktopEngineSiteImplementation(object):
         # this engine.
         self.startup_version = kwargs.get("startup_version")
         self.startup_descriptor = kwargs.get("startup_descriptor")
+        server = kwargs.get("server")
+
+        # Log usage statistics about the Shotgun Desktop executable and the desktop startup.
+        sgtk.util.log_user_attribute_metric("tk-framework-desktopstartup", self.startup_version)
+        sgtk.util.log_user_attribute_metric("Shotgun Desktop version", self.app_version)
+        # If a server is passed down from the desktop startup, it means we won't be using the engine-based
+        # websocket server.
+        sgtk.util.log_user_attribute_metric("Engine-Websockets", "no" if server else "yes")
 
         if self.uses_legacy_authentication():
             self._migrate_credentials()
@@ -273,7 +281,7 @@ class DesktopEngineSiteImplementation(object):
         # our websocket integration only if there is no server running from the desktop startup.
         # Note that the server argument is set regardless of whether the server launched or crashed,
         # so we have to actually get its value instead of merely checking for existence.
-        if kwargs.get("server") is None:
+        if server is None:
             # Initialize all of this after the style-sheet has been applied so any prompt are also
             # styled after the Shotgun Desktop's visual-style.
             splash.set_message("Initializing browser integration.")


### PR DESCRIPTION
Logs three user attributes:

`Shotgun Desktop version`: Version of the Shotgun desktop. Note that it suffixes the word `version` like we do for other DCCs.

`tk-framework-desktopstartup`: Version of the desktop startup framework. Note that we don't suffix the `version` keyword, just like we do for other Toolkit bundles.

`Engine-Websockets`: If "yes", then we are using the websocket integration that comes with the desktop engine, otherwise we're in legacy mode.

That last statistic will be useful to know if we can deprecate the bundling of the desktop server code in the startup framework.
