### PR TITLE
For #43159, chrome 59 fix

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -140,4 +140,4 @@ frameworks:
     - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.6.0"}
     - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.1.0"}
     - {"name": "tk-framework-adminui", "version": "v0.x.x"}
-    - {"name": "tk-framework-desktopserver", "version": "v1.x.x"}
+    - {"name": "tk-framework-desktopserver", "version": "v1.x.x", "minimum_version": "v1.1.0"}

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -247,7 +247,8 @@ class DesktopEngineSiteImplementation(object):
         icon = QtGui.QIcon(":tk-desktop/default_systray_icon")
         app.setWindowIcon(icon)
 
-        splash.set_message("Building UI")
+        if splash:
+            splash.set_message("Building UI")
 
         # setup the global look and feel
         self._engine._initialize_dark_look_and_feel()
@@ -276,10 +277,13 @@ class DesktopEngineSiteImplementation(object):
         if kwargs.get("server") is None:
             # Initialize all of this after the style-sheet has been applied so any prompt are also
             # styled after the Shotgun Desktop's visual-style.
-            splash.set_message("Initializing browser integration.")
+            if splash:
+                splash.set_message("Initializing browser integration.")
             try:
                 desktop_server_framework = sgtk.platform.get_framework("tk-framework-desktopserver")
-                desktop_server_framework.launch_desktop_server(self._user.host, self._current_login["id"])
+                desktop_server_framework.launch_desktop_server(
+                    self._user.host, self._current_login["id"], parent=splash
+                )
             except Exception:
                 logger.exception("Unexpected error while trying to launch the browser integration:")
             else:

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -370,6 +370,18 @@ class DesktopWindow(SystrayWindow):
         self.user_menu.exec_(event.globalPos())
 
     def _show_rich_message_box(self, icon, title, message, buttons=[]):
+        """
+        Shows a QMessageBox that supports HTML formatting.
+
+        :param icon: Icon to use.
+        :type icon: ``QtGui.QMessageBox.Icon``
+        :param str title: Title of the dialog.
+        :param str message: Message to display.
+        :param list buttons: List of `QtGui.QMessageBox.StandardButton` to display.
+
+        :returns: `QtGui.QMessageBox.StandardButton` value associated with the button
+            that was pressed.
+        """
         message_box = QtGui.QMessageBox(self)
         message_box.setIcon(icon)
         message_box.setTextFormat(QtCore.Qt.RichText)
@@ -380,6 +392,10 @@ class DesktopWindow(SystrayWindow):
         return message_box.exec_()
 
     def handle_regen_certs(self):
+        """
+        Regenerates the certificates if the user is certain and restarts the Shotgun Desktop on
+        demand.
+        """
 
         # Need to create the message box by hand to have rich text format, hence
         # clickable Urls.
@@ -420,7 +436,7 @@ class DesktopWindow(SystrayWindow):
                 )
             )
         else:
-            result = QtGui.QMessageBox.question(
+            choice = QtGui.QMessageBox.question(
                 self,
                 "Shotgun browser integration",
                 "The Shotgun Desktop needs to restart for the certificate changes "
@@ -429,7 +445,7 @@ class DesktopWindow(SystrayWindow):
                 "Would you like to restart?",
                 QtGui.QMessageBox.Yes | QtGui.QMessageBox.No
             )
-            if result == QtGui.QMessageBox.Yes:
+            if choice == QtGui.QMessageBox.Yes:
                 self._restart_desktop()
 
     def handle_project_command_expanded_changed(self, group_key, expanded):

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -157,15 +157,18 @@ class DesktopWindow(SystrayWindow):
         name_action = self.user_menu.addAction(current_user["name"])
         url_action = self.user_menu.addAction(connection.base_url.split("://")[1])
         self.user_menu.addSeparator()
+        advanced_menu = self.user_menu.addMenu("Advanced")
         self.user_menu.addAction(self.ui.actionPin_to_Menu)
         self.user_menu.addAction(self.ui.actionKeep_on_Top)
-        self.user_menu.addAction(self.ui.actionShow_Console)
         self.user_menu.addAction(self.ui.actionRefresh_Projects)
         self.user_menu.addAction(self.ui.actionAdvanced_Project_Setup)
         about_action = self.user_menu.addAction("About...")
         self.user_menu.addSeparator()
         self.user_menu.addAction(self.ui.actionSign_Out)
         self.user_menu.addAction(self.ui.actionQuit)
+
+        advanced_menu.addAction(self.ui.actionShow_Console)
+        advanced_menu.addAction(self.ui.actionRegenerate_Certificates)
 
         # Initially hide the Advanced project setup... menu item. This
         # menu item will only be displayed for projects that do not have
@@ -185,6 +188,7 @@ class DesktopWindow(SystrayWindow):
         self.ui.actionRefresh_Projects.triggered.connect(self.handle_project_refresh_action)
         self.ui.actionSign_Out.triggered.connect(self.sign_out)
         self.ui.actionQuit.triggered.connect(self.handle_quit_action)
+        self.ui.actionRegenerate_Certificates.triggered.connect(self.handle_regen_certs)
 
         self.ui.user_button.setMenu(self.user_menu)
 
@@ -364,6 +368,69 @@ class DesktopWindow(SystrayWindow):
     # Event handlers and slots
     def contextMenuEvent(self, event):
         self.user_menu.exec_(event.globalPos())
+
+    def _show_rich_message_box(self, icon, title, message, buttons=[]):
+        message_box = QtGui.QMessageBox(self)
+        message_box.setIcon(icon)
+        message_box.setTextFormat(QtCore.Qt.RichText)
+        message_box.setWindowTitle(title)
+        message_box.setText(message)
+        for button in buttons:
+            message_box.addButton(button)
+        return message_box.exec_()
+
+    def handle_regen_certs(self):
+
+        # Need to create the message box by hand to have rich text format, hence
+        # clickable Urls.
+        choice = self._show_rich_message_box(
+            QtGui.QMessageBox.Information,
+            "Shotgun browser integration",
+            "Regenerating the Shotgun Desktop's browser integration certificates should "
+            "only be done if you have issues with the browser integration.<br/>"
+            "<br/>"
+            "If you are unsure how to proceed, we recommend you visit our support page "
+            "to troubleshoot connections with <a href='%s'>Chrome</a> or "
+            "<a href='%s'>Firefox</a>.<br/>"
+            "<br/>"
+            "Would you like to continue?" % (
+                "https://support.shotgunsoftware.com/hc/en-us/articles/114094536273",
+                "https://support.shotgunsoftware.com/hc/en-us/articles/115000054954"
+            ),
+            [QtGui.QMessageBox.Yes, QtGui.QMessageBox.No]
+        )
+
+        if choice != QtGui.QMessageBox.Yes:
+            return
+
+        try:
+            desktop_server_framework.regenerate_certificates(self)
+        except Exception:
+            log.exception("Unexpected error while regenerating certificates:")
+            self._show_rich_message_box(
+                QtGui.QMessageBox.Critical,
+                "Shotgun browser integration",
+                "It appears there are an issue while regenerating the certificates."
+                "\n"
+                "Please contact <a href='{0}'>our support team</a> "
+                "if you need assistance resolving this issue. Make sure to attach the logs found "
+                "at <a href='file://{1}'>{1}</a>.".format(
+                    "mailto:support@shotgunsoftware.com",
+                    sgtk.LogManager().base_file_handler.baseFilename
+                )
+            )
+        else:
+            result = QtGui.QMessageBox.question(
+                self,
+                "Shotgun browser integration",
+                "The Shotgun Desktop needs to restart for the certificate changes "
+                "to take effect.\n"
+                "\n"
+                "Would you like to restart?",
+                QtGui.QMessageBox.Yes | QtGui.QMessageBox.No
+            )
+            if result == QtGui.QMessageBox.Yes:
+                self._restart_desktop()
 
     def handle_project_command_expanded_changed(self, group_key, expanded):
         expanded_state = self._project_command_model.get_expanded_state()

--- a/python/tk_desktop/ui/desktop_window.py
+++ b/python/tk_desktop/ui/desktop_window.py
@@ -374,6 +374,8 @@ class Ui_DesktopWindow(object):
         self.actionRefresh_Projects.setObjectName("actionRefresh_Projects")
         self.actionAdvanced_Project_Setup = QtGui.QAction(DesktopWindow)
         self.actionAdvanced_Project_Setup.setObjectName("actionAdvanced_Project_Setup")
+        self.actionRegenerate_Certificates = QtGui.QAction(DesktopWindow)
+        self.actionRegenerate_Certificates.setObjectName("actionRegenerate_Certificates")
 
         self.retranslateUi(DesktopWindow)
         self.stack.setCurrentIndex(0)
@@ -412,6 +414,8 @@ class Ui_DesktopWindow(object):
         self.actionRefresh_Projects.setToolTip(QtGui.QApplication.translate("DesktopWindow", "Refreshes the project information.", None, QtGui.QApplication.UnicodeUTF8))
         self.actionAdvanced_Project_Setup.setText(QtGui.QApplication.translate("DesktopWindow", "Advanced project setup...", None, QtGui.QApplication.UnicodeUTF8))
         self.actionAdvanced_Project_Setup.setToolTip(QtGui.QApplication.translate("DesktopWindow", "Launch the classic project setup wizard", None, QtGui.QApplication.UnicodeUTF8))
+        self.actionRegenerate_Certificates.setText(QtGui.QApplication.translate("DesktopWindow", "Regenerate Certificates", None, QtGui.QApplication.UnicodeUTF8))
+        self.actionRegenerate_Certificates.setToolTip(QtGui.QApplication.translate("DesktopWindow", "Regenerates browser integration certificates", None, QtGui.QApplication.UnicodeUTF8))
 
 from ..action_list_view import ActionListView
 from ..grouping_list_view import GroupingListView

--- a/resources/desktop_window.ui
+++ b/resources/desktop_window.ui
@@ -944,6 +944,14 @@
     <string>Launch the classic project setup wizard</string>
    </property>
   </action>
+  <action name="actionRegenerate_Certificates">
+   <property name="text">
+    <string>Regenerate Certificates</string>
+   </property>
+   <property name="toolTip">
+    <string>Regenerates browser integration certificates</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>


### PR DESCRIPTION
Chrome 59 on Mac breaks browser integration because our certificate doesn't report the correct certificate version. Version 3 of the certificate is the one that accepts X5009 extensions.

We're adding a new `Advanced` submenu in the user menu, which now allows to regenerate certificates.

This should be code reviewed in tandem with [this](https://github.com/shotgunsoftware/tk-framework-desktopserver/pull/34)