### PR TITLE
#43719: Standard styling for site level panels

### DIFF
--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -142,8 +142,14 @@ class DesktopEngineSiteImplementation(object):
         """
         self._engine.log_debug("Registering panel \"%s\" (id %s) as a tab." %
                                (title, panel_id))
+        # create widget
         widget = widget_class(*args, **kwargs)
-
+        # apply std toolkit stylings
+        # note: since this class is an engine but doesn't derive from
+        #       engine, we have to call the protected method via bundle.engine
+        #       rather than using self._apply_external_stylesheet()
+        bundle.engine._apply_external_stylesheet(bundle, widget)
+        # register UI tab
         self.desktop_window.register_tab(title, widget)
 
     def startup_rpc(self):


### PR DESCRIPTION
This minor change applies toolkit standard stylings to custom panels.

Previously, styling for custom panels was not being picked up, resulting in for example the Shotgun panel running as a tab inside of desktop looking non-standard. This fix resolves this issue:

<img width="427" alt="screen shot 2017-07-16 at 23 34 55" src="https://user-images.githubusercontent.com/337710/28251951-d18a9558-6a80-11e7-97df-fcb5d738e534.png">
