### PR TITLE
For #43813: Adds a debug logging toggle action to the Advanced menu.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -51,6 +51,18 @@ class DesktopEngine(Engine):
         """
         return self._host_info
 
+    @property
+    def register_toggle_debug_command(self):
+        """
+        Indicates that the tk-desktop engine should not receive a toggle debug
+        engine command during engine initialization. The desktop engine provides
+        its own debug logging toggle via the advanced menu provided by the engine's
+        internal module.
+
+        :rtype: bool
+        """
+        return False
+
 
     ############################################################################
     # Engine methods

--- a/python/tk_desktop/communication_base.py
+++ b/python/tk_desktop/communication_base.py
@@ -32,6 +32,18 @@ class CommunicationBase(object):
         self._msg_server = None
         self._proxy = None
 
+    @property
+    def is_connected(self):
+        """
+        Indicates whether there a live connection.
+
+        :rtype: bool
+        """
+        return (
+            self._proxy is not None and
+            not self._proxy.is_closed()
+        )
+
     def shut_down(self):
         """
         Disconnects from the other process and shuts down the local server.

--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -102,6 +102,15 @@ class DesktopEngineProjectImplementation(object):
         self._project_comm.register_function(self._test_project_locations, "test_project_locations")
         self._project_comm.register_function(self._open_project_locations, "open_project_locations")
         self._project_comm.register_function(self._get_setting, "get_setting")
+        self._project_comm.register_function(self._set_global_debug, "set_global_debug")
+
+    def _set_global_debug(self, state):
+        """
+        Sets the global debug to the given state.
+
+        :param bool state: The debug state to set.
+        """
+        sgtk.LogManager().global_debug = state
 
     def _register_groups(self):
         # get the list of configured groups

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -51,6 +51,22 @@ class DesktopEngineSiteImplementation(object):
         shotgun_globals.unregister_bg_task_manager(self._task_manager)
         self.site_comm.shut_down()
 
+    def set_global_debug(self, state):
+        """
+        Attempts to tell a project subprocess to set the state of
+        the global debug logging setting. This will never raise
+        an exception, but a warning message will be logged if something
+        causes the RPC call to raise.
+
+        :param bool state: The debug to set.
+        """
+        try:
+            self.site_comm.call_no_response("set_global_debug", state)
+        except Exception:
+            # This really can't be a debug log call, because we might have just
+            # toggled debug logging off, in which case the message would not be
+            # logged.
+            logger.warning("RPC call to set_global_debug did not succeed.")
 
     ###########################################################################
     # panel support (displayed as tabs)

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -60,13 +60,24 @@ class DesktopEngineSiteImplementation(object):
 
         :param bool state: The debug to set.
         """
-        try:
-            self.site_comm.call_no_response("set_global_debug", state)
-        except Exception:
-            # This really can't be a debug log call, because we might have just
-            # toggled debug logging off, in which case the message would not be
-            # logged.
-            logger.warning("RPC call to set_global_debug did not succeed.")
+        if self.site_comm.is_connected:
+            try:
+                self.site_comm.call_no_response("set_global_debug", state)
+            except Exception:
+                # This really can't be a debug log call, because we might have just
+                # toggled debug logging off, in which case the message would not be
+                # logged.
+                logger.warning(
+                    "The RPC call to set_global_debug did not succeed. This is likely "
+                    "caused by an older version of the tk-desktop engine being "
+                    "used by the project. This issue can be resolved by updating to "
+                    "the latest version of tk-desktop using the 'tank updates' command."
+                )
+        else:
+            logger.debug(
+                "No connection exists to a project subprocess. No debug "
+                "toggling will occur via RPC as a result."
+            )
 
     ###########################################################################
     # panel support (displayed as tabs)

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -195,8 +195,14 @@ class DesktopWindow(SystrayWindow):
         # it.
         if sgtk.constants.DEBUG_LOGGING_ENV_VAR in os.environ:
             self.toggle_debug_action.setEnabled(False)
+            self.toggle_debug_action.setToolTip(
+                "The %s environment variable is set, which has forced debug logging on." %
+                sgtk.constants.DEBUG_LOGGING_ENV_VAR
+            )
         else:
+            self.toggle_debug_action.setToolTip("Toggles debug logging for Desktop's site context.")
             debug_user_pref = self.user_preferred_debug_logging
+
             if debug_user_pref is not None:
                 self.toggle_debug_action.setChecked(debug_user_pref)
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -159,15 +159,6 @@ class DesktopWindow(SystrayWindow):
         self.user_menu.addSeparator()
         advanced_menu = self.user_menu.addMenu("Advanced")
 
-        # We will end up with a disable advanced menu item for the
-        # debug logging toggle if TK_DEBUG is set in the environment,
-        # so we want it to be a bit more obvious that the action is
-        # disabled than we get out of the box.
-        advanced_menu.setStyleSheet(
-            """
-            QMenu::item:disabled { color: rgb(100, 100, 100); }
-            """
-        )
         self.user_menu.addAction(self.ui.actionPin_to_Menu)
         self.user_menu.addAction(self.ui.actionKeep_on_Top)
         self.user_menu.addAction(self.ui.actionRefresh_Projects)
@@ -184,27 +175,13 @@ class DesktopWindow(SystrayWindow):
         self.toggle_debug_action = QtGui.QAction("Toggle Debug Logging", advanced_menu)
         self.toggle_debug_action.setCheckable(True)
         self.toggle_debug_action.setChecked(sgtk.LogManager().global_debug)
+
+        debug_user_pref = self.user_preferred_debug_logging
+        if debug_user_pref is not None:
+            self.toggle_debug_action.setChecked(debug_user_pref)
+
         self.toggle_debug_action.toggled.connect(self._debug_toggled)
-
         advanced_menu.addAction(self.toggle_debug_action)
-
-        # In the case of TK_DEBUG, we want to disable the control and set a tooltip 
-        # that explains why. We treat the TK_DEBUG env var as a complete override,
-        # otherwise we can check stored user settings. If the user previously set
-        # the logging on or off explicitly via this menu action then we'll remember
-        # it.
-        if sgtk.constants.DEBUG_LOGGING_ENV_VAR in os.environ:
-            self.toggle_debug_action.setEnabled(False)
-            self.toggle_debug_action.setToolTip(
-                "The %s environment variable is set, which has forced debug logging on." %
-                sgtk.constants.DEBUG_LOGGING_ENV_VAR
-            )
-        else:
-            self.toggle_debug_action.setToolTip("Toggles debug logging for Desktop's site context.")
-            debug_user_pref = self.user_preferred_debug_logging
-
-            if debug_user_pref is not None:
-                self.toggle_debug_action.setChecked(debug_user_pref)
 
         if (
             desktop_server_framework.can_run_server() and
@@ -323,6 +300,7 @@ class DesktopWindow(SystrayWindow):
         """
         self.user_preferred_debug_logging = state
         sgtk.LogManager().global_debug = state
+        sgtk.platform.current_engine().set_global_debug(state)
 
     def _get_user_preferred_debug_logging(self):
         """

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -175,12 +175,12 @@ class DesktopWindow(SystrayWindow):
         self.toggle_debug_action = QtGui.QAction("Toggle Debug Logging", advanced_menu)
         self.toggle_debug_action.setCheckable(True)
         self.toggle_debug_action.setChecked(sgtk.LogManager().global_debug)
+        self.toggle_debug_action.toggled.connect(self._debug_toggled)
 
         debug_user_pref = self.user_preferred_debug_logging
         if debug_user_pref is not None:
             self.toggle_debug_action.setChecked(debug_user_pref)
 
-        self.toggle_debug_action.toggled.connect(self._debug_toggled)
         advanced_menu.addAction(self.toggle_debug_action)
 
         if (


### PR DESCRIPTION
The action follows these rules:

1. If TK_DEBUG is set in the environment, debug logging is always on and the menu action is disabled.
2. If the user previously used this menu action to turn debugging on or off, that is remembered in engine-level user settings and will be preserved when SG Desktop is relaunched.
3. If TK_DEBUG is not set in the environment and the user has not previously used this menu action to toggle debug logging on or off, the checked state of the action will match the global debug setting as reported by the LogManager.

The only bit here that is unfortunate is that QMenu in Qt4.x does not support showing tooltips for QActions. I've included tooltips anyway, as presumably someday this will be running in Qt 5.x and they'll just start showing properly.