### PR TITLE
Adds support to tk-desktop engine for the deny_permissions option when registering commands/app launchers.

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -129,8 +129,14 @@ class DesktopEngineProjectImplementation(object):
         self._project_comm.call("set_collapse_rules", collapse_rules)
 
     def _register_commands(self):
+        login = self._project_comm.call('get_current_login')
+
         # send the commands over to the proxy
         for name, command_info in self._engine.commands.iteritems():
+            deny_permissions = command_info['properties'].get('deny_permissions')
+            if deny_permissions and login['permission_rule_set']['name'] in deny_permissions:
+                continue
+
             self.__callback_map[("__commands", name)] = command_info["callback"]
             # pull out needed values since this needs to be pickleable
             gui_properties = {}

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -193,6 +193,7 @@ class DesktopEngineSiteImplementation(object):
         self.site_comm.register_function(self.set_collapse_rules, "set_collapse_rules")
         self.site_comm.register_function(self.trigger_register_command, "trigger_register_command")
         self.site_comm.register_function(self.project_commands_finished, "project_commands_finished")
+        self.site_comm.register_function(self.get_current_login, "get_current_login")
 
     def engine_startup_error(self, error, tb=None):
         """
@@ -387,7 +388,7 @@ class DesktopEngineSiteImplementation(object):
         self._current_login = self._engine.sgtk.shotgun.find_one(
             "HumanUser",
             [["login", "is", human_user.login]],
-            ["id", "login"]
+            ["id", "login", "permission_rule_set"]
         )
 
         # Initialize Qt app


### PR DESCRIPTION
The base sgtk Engine already supports a ``deny_permissions`` option when registering commands, but currently, it is only supported by the tk-shotgun engine.  This adds support for the option to the tk-desktop engine as well.  This allows finer control over which SG Desktop application launchers are available based on permission roles.