### PR TITLE
43269 desktop reload and restart menu item dupes 2

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1052,6 +1052,12 @@ class DesktopWindow(SystrayWindow):
         project = item.data(SgProjectModel.SG_DATA_ROLE)
         self.__launch_app_proxy_for_project(project)
 
+    def _on_project_menu_triggered(self, action):
+        pc_id = action.property("project_configuration_id")
+
+        if pc_id is not None:
+            self.__launch_app_proxy_for_project(self.current_project, pc_id)
+
     def _on_setup_finished(self, success):
         if success:
             self.__launch_app_proxy_for_project(self.current_project)

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1053,6 +1053,12 @@ class DesktopWindow(SystrayWindow):
         self.__launch_app_proxy_for_project(project)
 
     def _on_project_menu_triggered(self, action):
+        """
+        Called just after user has selected a project menu option or pipeline configuration.
+        The methods acts only on a pipeline configuration choice.
+
+        :param action: a QAction as selected by user.
+        """
         pc_id = action.property("project_configuration_id")
 
         if pc_id is not None:

--- a/python/tk_desktop/project_menu.py
+++ b/python/tk_desktop/project_menu.py
@@ -163,9 +163,16 @@ class ProjectMenu(object):
         self._parent.ui.actionProject_Filesystem_Folder.setVisible(has_project_locations)
 
     def _on_project_menu_triggered(self, action):
+        """
+        Called just after user has selected a project menu option or pipeline configuration
 
-        # Forwards to `parent` so the `__launch_app_proxy_for_project` private methods
-        # can proceed with setting up project and request ui update as required.
+        Forwards to `parent` so the `__launch_app_proxy_for_project` private methods
+        can proceed with setting up project and request ui update as required.
+
+        NOTE: The parent version of the this method only acts on a pipeline configuration choice.
+
+        :param action: a QAction as selected by user.
+        """
         self._parent._on_project_menu_triggered(action)
 
 

--- a/python/tk_desktop/project_menu.py
+++ b/python/tk_desktop/project_menu.py
@@ -18,8 +18,8 @@ log = get_logger(__name__)
 
 class ProjectMenu(object):
     """
-    Encalsulate specific functionalities relating ot the project menu.
-    This class was mostly created to lighten the `DesktopWindow` class.
+    Encapsulate specific functionality relating of the project menu.
+    This class was created to lighten the `DesktopWindow` class.
     """
     def __init__(self, parent):
         """
@@ -160,10 +160,10 @@ class ProjectMenu(object):
         self._parent.ui.actionProject_Filesystem_Folder.setVisible(has_project_locations)
 
     def _on_project_menu_triggered(self, action):
-        pc_id = action.property("project_configuration_id")
 
-        if pc_id is not None:
-            self._parent.__launch_app_proxy_for_project(self.current_project, pc_id)
+        # Forwards to `parent` so the `__launch_app_proxy_for_project` private methods
+        # can proceed with setting up project and request ui update as required.
+        self._parent._on_project_menu_triggered(action)
 
 
 

--- a/python/tk_desktop/project_menu.py
+++ b/python/tk_desktop/project_menu.py
@@ -98,11 +98,13 @@ class ProjectMenu(object):
         action = QtGui.QWidgetAction(self._parent)
         action.setDefaultWidget(label)
         self._project_menu.addAction(action)
+        pipelineConfigsMenuGroup = QtGui.QActionGroup(self._parent)
+        pipelineConfigsMenuGroup.setExclusive(True)
         # Group every sandboxes by their name and add pipelines one at a time
         for pc_name, pc_group in itertools.groupby(pipeline_configurations, lambda x: x["name"]):
-            self._add_pipeline_group_to_menu(list(pc_group), selected)
+            self._add_pipeline_group_to_menu(pipelineConfigsMenuGroup, list(pc_group), selected)
 
-    def _add_pipeline_group_to_menu(self, pc_group, selected):
+    def _add_pipeline_group_to_menu(self, parent_action_group, pc_group, selected):
         """
         Adds a group of pipelines to the menu.
 
@@ -127,6 +129,7 @@ class ProjectMenu(object):
                 unique_pc_name = pc["name"]
 
             action = self._project_menu.addAction(unique_pc_name)
+            action.setActionGroup(parent_action_group)
             action.setCheckable(True)
             action.setProperty("project_configuration_id", pc["id"])
 
@@ -164,6 +167,7 @@ class ProjectMenu(object):
         # Forwards to `parent` so the `__launch_app_proxy_for_project` private methods
         # can proceed with setting up project and request ui update as required.
         self._parent._on_project_menu_triggered(action)
+
 
 
 


### PR DESCRIPTION
I was trying to understand what was creating a radio button like behavior in the code but couldn't find anything. Until I realized that the radio-button-like behavior was done by simply recreating the options all of the time and 'checking' the user choice.

There are two distinct commits in this pull request:
- Fixes a bug introduced in the last commit
- Replace UI checkboxes with actual radio buttons.

The second one is really optional and up to reviewer. The change is just a visual one. The behavior remains the same.

![sg_desktop_checkboxes](https://user-images.githubusercontent.com/5750337/33243145-4de8e790-d2ae-11e7-9eca-a471583d2258.png)
![sg_desktop_radio_buttons](https://user-images.githubusercontent.com/5750337/33243146-4e0673be-d2ae-11e7-90e0-9520debdec23.png)