### PR TITLE
For #43269: Fix issue with single configuration pipeline

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -989,7 +989,7 @@ class DesktopWindow(SystrayWindow):
         self.install_apps_widget.hide()
         self.project_overlay.hide()
 
-        self._project_menu.clear()
+        self._project_menu.reset()
 
     def clear_actions_from_project_menu(self):
         self._project_menu.clear_actions()

--- a/python/tk_desktop/project_menu.py
+++ b/python/tk_desktop/project_menu.py
@@ -39,11 +39,13 @@ class ProjectMenu(object):
         """
         self._project_menu.insertAction(self._pipeline_configuration_separator, action)
 
-    def clear(self):
+    def reset(self):
         """
-        Clears the project specific menu
+        Clears the project specific related QT menu and add basic menu actions
+        and pipeline configuration section divider.
         """
         if self._project_menu:
+            self._pipeline_configuration_separator = None
             self._project_menu.clear()
 
         self._project_menu = QtGui.QMenu(self._parent)
@@ -53,6 +55,10 @@ class ProjectMenu(object):
         self._parent.ui.actionProject_Filesystem_Folder.setVisible(True)
         self._project_menu.addAction(self._parent.ui.actionProject_Filesystem_Folder)
         self._parent.ui.project_menu.setMenu(self._project_menu)
+
+        # Add a section separator that will be above the pipeline configurations.
+        # The context menu actions will be inserted above this saparator.
+        self._pipeline_configuration_separator = self._project_menu.addSeparator()
 
     def clear_actions(self):
         """
@@ -89,9 +95,6 @@ class ProjectMenu(object):
             return
 
         log.debug("More than one pipeline configuration was found, building menu.")
-
-        # Add a separator that will be above the pipeline configurations. Context menu actions will go over that.
-        self._pipeline_configuration_separator = self._project_menu.addSeparator()
 
         # Build the configuration section header.
         label = QtGui.QLabel("CONFIGURATION")


### PR DESCRIPTION
Moved the creation of the menu separator to the 'ProjectMenu.clear()' which was also renamed 'rese()' for clarity. On switching back and forth between a multi-configuration pipeline and a single configuration pipeline, a call to the 'ProjectMenu.clear()'  method would be made. The later clears the QT menu and the '_pipeline_configuration_separator' instance member would then reference a deleted QT object.