### PR TITLE
For #46128, multiple endpoints in toolkit ini

### DIFF
--- a/python/tk_desktop/console.py
+++ b/python/tk_desktop/console.py
@@ -14,7 +14,7 @@ import logging
 from sgtk.platform.qt import QtGui
 from sgtk.platform.qt import QtCore
 
-from .ui import resources_rc
+from .ui import resources_rc # noqa
 
 
 settings = sgtk.platform.import_framework("tk-framework-shotgunutils", "settings")
@@ -37,13 +37,12 @@ class ConsoleLogHandler(logging.Handler):
 
     def __init__(self, console):
         logging.Handler.__init__(self)
-        self.__console = console
         self.__formatter = logging.Formatter("%(asctime)s [%(levelname) 8s] %(message)s")
 
         # Wrap the real message logging with a signal/slot,
         # to ensure that the console is updated within the UI thread.
         self.__signals = self.LogSignaller()
-        self.__signals.log_message.connect(self.__console.append_text)
+        self.__signals.log_message.connect(console.append_text)
 
     def emit(self, record):
         # Convert the record to pretty HTML
@@ -86,6 +85,9 @@ class Console(QtGui.QDialog):
 
         self.move(pos)
         self.resize(size)
+
+        self.__console_handler = ConsoleLogHandler(self)
+        sgtk.LogManager().initialize_custom_handler(self.__console_handler)
 
     def on_logs_context_menu_request(self, point):
         menu = self.__logs.createStandardContextMenu()

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1302,6 +1302,7 @@ class DesktopWindow(SystrayWindow):
                 }
             }
             (_, pickle_data_file) = tempfile.mkstemp(suffix='.pkl')
+            log.info("Using tentative insecure pickle fix.")
             with open(pickle_data_file, "wb") as pickle_data_file_handle:
                 pickle.dump(desktop_data, pickle_data_file_handle)
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1302,7 +1302,8 @@ class DesktopWindow(SystrayWindow):
                 }
             }
             (_, pickle_data_file) = tempfile.mkstemp(suffix='.pkl')
-            pickle.dump(desktop_data, open(pickle_data_file, "wb"))
+            with open(pickle_data_file, "wb") as pickle_data_file_handle:
+                pickle.dump(desktop_data, pickle_data_file_handle)
 
             # update the values on the project updater in case they are needed
             self.update_project_config_widget.set_project_info(

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -16,7 +16,6 @@ import tempfile
 import subprocess
 import cPickle as pickle
 import pprint
-import urlparse
 import inspect
 from collections import OrderedDict
 
@@ -34,8 +33,6 @@ from sgtk.platform import get_logger
 from .ui import resources_rc # noqa
 from .ui import desktop_window
 
-from .console import Console
-from .console import ConsoleLogHandler
 from .systray import SystrayWindow
 from .about_screen import AboutScreen
 from .no_apps_installed_overlay import NoAppsInstalledOverlay
@@ -83,7 +80,7 @@ class DesktopWindow(SystrayWindow):
     _CHROME_SUPPORT_URL = "https://support.shotgunsoftware.com/hc/en-us/articles/114094536273"
     _FIREFOX_SUPPORT_URL = "https://support.shotgunsoftware.com/hc/en-us/articles/115000054954"
 
-    def __init__(self, parent=None):
+    def __init__(self, console, parent=None):
         SystrayWindow.__init__(self, parent)
 
         # initialize member variables
@@ -125,9 +122,7 @@ class DesktopWindow(SystrayWindow):
         connection = engine.get_current_user().create_sg_connection()
 
         # Setup the console
-        self.__console = Console()
-        self.__console_handler = ConsoleLogHandler(self.__console)
-        sgtk.LogManager().initialize_custom_handler(self.__console_handler)
+        self.__console = console
 
         # User menu
         ###########################
@@ -982,9 +977,11 @@ class DesktopWindow(SystrayWindow):
         self._save_setting("project_id", 0, site_specific=True)
         try:
             from sgtk.util.metrics import EventMetric as EventMetric
-            EventMetric.log(EventMetric.GROUP_NAVIGATION,
-                             "Viewed Projects",
-                             bundle=engine)
+            EventMetric.log(
+                EventMetric.GROUP_NAVIGATION,
+                "Viewed Projects",
+                bundle=engine
+            )
         except:
             # ignore all errors. ex: using a core that doesn't support metrics
             pass
@@ -1215,7 +1212,10 @@ class DesktopWindow(SystrayWindow):
                 self._save_setting(setting_name, pipeline_configuration_to_load["id"], site_specific=True)
 
             # Add all the pipeline configurations to the menu.
-            self._project_menu.populate_pipeline_configurations_menu(pipeline_configurations, pipeline_configuration_to_load)
+            self._project_menu.populate_pipeline_configurations_menu(
+                pipeline_configurations,
+                pipeline_configuration_to_load
+            )
 
             # If there is no pipeline configuration set for the current project, i.e. there might be
             # site level ones but no project ones, add the Advanced Project Setup menu.
@@ -1302,7 +1302,6 @@ class DesktopWindow(SystrayWindow):
                 }
             }
             (_, pickle_data_file) = tempfile.mkstemp(suffix='.pkl')
-            log.info("Using tentative insecure pickle fix.")
             with open(pickle_data_file, "wb") as pickle_data_file_handle:
                 pickle.dump(desktop_data, pickle_data_file_handle)
 


### PR DESCRIPTION
While working on the new features for the multiple endpoints in toolkit.ini I found it very frustrating to debug browser integration crashes in the desktop, since these errors are not shown in the debug console, which also makes debugging harder for our clients.

I've therefore moved the initialization of Qt and the look and feel at the beggining of the `run` method. The debug console can therefore be initialized earlier and more debugging messages end up there.

Therefore, those kind of error messages will now show in the console instead of having to look at the log file.

![screen shot 2018-01-18 at 10 00 48](https://user-images.githubusercontent.com/8126447/35155875-0a0df9b0-fcfd-11e7-8060-1e1cc45579e1.png)
