### PR TITLE
Fix issue with tk-desktop stomping on a specified authenticated user with the default user

### DIFF
--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -416,16 +416,19 @@ class DesktopEngineSiteImplementation(object):
         if self.uses_legacy_authentication():
             self._migrate_credentials()
 
-        # We need to initialize current login
-        # We know for sure there is a default user, since either the migration was done
-        # or we logged in as an actual user with the new installer.
-        human_user = ShotgunAuthenticator(
-            # We don't want to get the script user, but the human user, so tell the
-            # CoreDefaultsManager manager that we are not interested in the script user. Do not use
-            # the regular shotgun_authentication.DefaultsManager to get this user because it will
-            # not know about proxy information.
-            sgtk.util.CoreDefaultsManager(mask_script_user=True)
-        ).get_default_user()
+        human_user = sgtk.get_authenticated_user()
+        if not human_user:
+            # We need to initialize current login
+            # We know for sure there is a default user, since either the migration was done
+            # or we logged in as an actual user with the new installer.
+            human_user = ShotgunAuthenticator(
+                # We don't want to get the script user, but the human user, so tell the
+                # CoreDefaultsManager manager that we are not interested in the script user. Do not use
+                # the regular shotgun_authentication.DefaultsManager to get this user because it will
+                # not know about proxy information.
+                sgtk.authentication.CoreDefaultsManager(mask_script_user=True)
+            ).get_default_user()
+
         # Cache the user so we can refresh the credentials before launching a background process
         self._user = human_user
         # Retrieve the current logged in user information. This will be used when creating


### PR DESCRIPTION
This fixes an issue where the previously authenticated user (initiated during tk-framework-desktopstartup's startup.py execution) is being overridden by tk-desktop setting the current user to CoreDefaultManager's default user. This bit us when attempting to have artists switch back and forth between multiple Shotgun servers, and the connection url being incorrect since it gets pulled from the default user rather than the authenticated user.