### PR TITLE
For #46757, gentler error when `tank_name` is not set.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -158,10 +158,10 @@ description: "The engine that runs inside the Shotgun Desktop Application"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.18.138"
+requires_core_version: "v0.18.139"
 
 frameworks:
-    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.7.4"}
+    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.8.0"}
     - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.1.0"}
     - {"name": "tk-framework-adminui", "version": "v0.x.x"}
     - {"name": "tk-framework-desktopserver", "version": "v1.x.x", "minimum_version": "v1.2.0"}

--- a/info.yml
+++ b/info.yml
@@ -158,7 +158,7 @@ description: "The engine that runs inside the Shotgun Desktop Application"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.18.97"
+requires_core_version: "v0.18.138"
 
 frameworks:
     - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.7.4"}

--- a/info.yml
+++ b/info.yml
@@ -161,7 +161,7 @@ requires_shotgun_version:
 requires_core_version: "v0.18.97"
 
 frameworks:
-    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.6.0"}
+    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.7.4"}
     - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.1.0"}
     - {"name": "tk-framework-adminui", "version": "v0.x.x"}
     - {"name": "tk-framework-desktopserver", "version": "v1.x.x", "minimum_version": "v1.2.0"}

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1168,15 +1168,24 @@ class DesktopWindow(SystrayWindow):
         trigger_project_config = False
         # If missing engine init error, we're know we have to setup the project.
         if isinstance(error, sgtk.platform.TankMissingEngineError):
-            message = "Error starting engine\n\n%s" % error.message
+            message = "Error starting engine!\n\n%s" % error.message
             trigger_project_config = True
         # However, this exception type hasn't always existed, so take care of that
         # case also.
         elif isinstance(error, sgtk.platform.TankEngineInitError):
-            message = "Error starting engine\n\n%s" % error.message
+            message = "Error starting engine!\n\n%s" % error.message
             # match directly on the error message until something less fragile can be put in place
             if error.message.startswith("Cannot find an engine instance tk-desktop"):
                 trigger_project_config = True
+        elif isinstance(error, sgtk.bootstrap.TankMissingTankNameError):
+            message = "Error starting engine!\n\n%s\n\n%s" % (
+                error.message.replace("tank_name", "<b>tank_name</b>"),
+                "Visit your "
+                "<b><a style='color: {0}' href='https://jf.shotgunstudio.com/detail/Project/{1}'>project</a></b> "
+                "page to set the field.".format(
+                    self.project_overlay.ERROR_COLOR, self.current_project["id"]
+                )
+            )
         else:
             message = "Error\n\n%s" % error.message
 


### PR DESCRIPTION
- Refactors the code a bit to use the overlay widget from qtwidgets
- Handles missing tank name errors by providing a hyperlink to the project's page.