### PR TITLE
For SG-6816, jump to project fix

### DIFF
--- a/python/tk_desktop/project_menu.py
+++ b/python/tk_desktop/project_menu.py
@@ -68,9 +68,11 @@ class ProjectMenu(object):
 
         # Loop through actions and delete the ones listed before the separator
         for action in actions:
-            if action in [
-                self._pipeline_configuration_separator, self._parent.ui.actionProject_Filesystem_Folder
-            ]:
+            # Do not delete the Jump To Filesystem menu. This one is hidden on demand instead.
+            if action == self._parent.ui.actionProject_Filesystem_Folder:
+                continue
+
+            if action == self._pipeline_configuration_separator:
                 # Found the separator, entering the pipeline
                 # config section, stop deleting items
                 break

--- a/python/tk_desktop/project_menu.py
+++ b/python/tk_desktop/project_menu.py
@@ -11,7 +11,7 @@
 import itertools
 import sgtk
 
-from tank.platform.qt import QtCore, QtGui
+from tank.platform.qt import QtGui
 from sgtk.platform import get_logger
 
 log = get_logger(__name__)
@@ -68,7 +68,9 @@ class ProjectMenu(object):
 
         # Loop through actions and delete the ones listed before the separator
         for action in actions:
-            if action == self._pipeline_configuration_separator:
+            if action in [
+                self._pipeline_configuration_separator, self._parent.ui.actionProject_Filesystem_Folder
+            ]:
                 # Found the separator, entering the pipeline
                 # config section, stop deleting items
                 break
@@ -151,9 +153,7 @@ class ProjectMenu(object):
         """
         Called just before the project specific menu is shown to the user.
         """
-
         engine = sgtk.platform.current_engine()
-
         try:
             # Get the availability of the project locations.
             has_project_locations = engine.site_comm.call("test_project_locations")
@@ -178,7 +178,3 @@ class ProjectMenu(object):
         :param action: a QAction as selected by user.
         """
         self._parent._on_project_menu_triggered(action)
-
-
-
-


### PR DESCRIPTION
When clearning the menu, do not remove the Jump To xxx action. This one gets turned on or off on demand.

Note that this only fixes the issue for classic configs. Bootstraped configs are running into an issue. 

The issue is simple. A path cache parent folder for a plugin based config is `p<project-id>c<pc-id>.<plugin-name>`. This means that every plugin has it's own copy of the path cache, therefore each plugin sync their updates in their own local path cache. Since desktop does not sync the path cache on startup, it is always empty, so the menu item will never appear.