### PR TITLE
Adjusted timing of overlay hiding before apps are shown, so they aren't erroneously highlighted.

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -79,6 +79,7 @@ class DesktopEngineProjectImplementation(object):
             self._connect_to_server()
             self._register_groups()
             self._register_commands()
+            self._project_comm.call("hide_overlay")
         except:
             # Same deal as during init_engine.
             self.destroy_engine()

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -189,6 +189,7 @@ class DesktopEngineSiteImplementation(object):
         self.site_comm.register_function(self.bootstrap_progress_callback, "bootstrap_progress")
         self.site_comm.register_function(self.engine_startup_error, "engine_startup_error")
         self.site_comm.register_function(self.set_groups, "set_groups")
+        self.site_comm.register_function(self.hide_overlay, "hide_overlay")
         self.site_comm.register_function(self.set_collapse_rules, "set_collapse_rules")
         self.site_comm.register_function(self.trigger_register_command, "trigger_register_command")
         self.site_comm.register_function(self.project_commands_finished, "project_commands_finished")
@@ -230,6 +231,9 @@ class DesktopEngineSiteImplementation(object):
     def set_groups(self, groups, show_recents=True):
         self.desktop_window.set_groups(groups, show_recents)
 
+    def hide_overlay(self):
+        self.desktop_window.project_overlay.hide()
+        
     def set_collapse_rules(self, collapse_rules):
         self._collapse_rules = collapse_rules
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1034,7 +1034,6 @@ class DesktopWindow(SystrayWindow):
     def set_groups(self, groups, show_recents=True):
         self._project_command_model.set_project(
             self.current_project, groups, show_recents=show_recents)
-        self.project_overlay.hide()
 
         key = "project_expanded_state.%d" % self.current_project["id"]
         expanded_state = self._load_setting(key, {}, True)


### PR DESCRIPTION
Hey tkFolk,

Here's a quick/dirty fix to the issue of apps that are erroneously highlighted during project load. See this WDI support ticket: https://support.shotgunsoftware.com/hc/en-us/requests/99803.

The only functional downside is: if users have the "Show Details" panel open, it very briefly is displayed on top of the apps as they are loading.

I'm sure there is a more elegant solution, but this works & is a small code change; I hope it prompts a "real" fix from someone who is more familiar with the app :)

Cheers,
Raphe