### PR TITLE
Sg 6422 proxy logging missing exception information

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -351,7 +351,7 @@ class DesktopEngineProjectImplementation(object):
             # If we have exception details, we need to format these and combine them with the message, as the traceback
             # object can't be serialize and passed over the proxy.
             if record.exc_info:
-                formatted_tracback = ''.join(traceback.format_tb(record.exc_info[2]))
+                formatted_tracback = ''.join(traceback.format_exception(*record.exc_info))
                 msg = "{msg}\n{traceback}".format(msg=record.msg, traceback=formatted_tracback)
             else:
                 msg = record.msg

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -50,11 +50,13 @@ class ProxyLoggingHandler(logging.Handler):
         if self._proxy.is_closed():
             return
 
-        msg = record.msg
         # if we have exception details, we need to format these and combine them with the message, as the traceback
         # object can't be serialize and passed over the proxy.
         if record.exc_info:
-            msg += "\n" + ''.join(traceback.format_tb(record.exc_info[2]))
+            formatted_tracback = ''.join(traceback.format_tb(record.exc_info[2]))
+            msg = "{msg}\n{traceback}".format(msg=record.msg, traceback=formatted_tracback)
+        else:
+            msg = record.msg
 
         try:
             self._proxy.call_no_response(

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -46,11 +46,15 @@ class ProxyLoggingHandler(logging.Handler):
         """
         Emits a log back to the host.
         """
+        # Note any changes made here, should also be considered for the
+        # `DesktopEngineProjectImplementation._emit_log_message` method in the
+        # desktop_engine_project_implementation module.
+
         # Do not send logs if the connection is closed!
         if self._proxy.is_closed():
             return
 
-        # if we have exception details, we need to format these and combine them with the message, as the traceback
+        # If we have exception details, we need to format these and combine them with the message, as the traceback
         # object can't be serialize and passed over the proxy.
         if record.exc_info:
             formatted_tracback = ''.join(traceback.format_tb(record.exc_info[2]))

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -51,6 +51,8 @@ class ProxyLoggingHandler(logging.Handler):
             return
 
         msg = record.msg
+        # if we have exception details, we need to format these and combine them with the message, as the traceback
+        # object can't be serialize and passed over the proxy.
         if record.exc_info:
             msg += "\n" + ''.join(traceback.format_tb(record.exc_info[2]))
 

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -58,7 +58,7 @@ class ProxyLoggingHandler(logging.Handler):
             self._proxy.call_no_response(
                 "proxy_log", record.levelno, msg, record.args
             )
-        except Exception as e:
+        except Exception:
             # If something couldn't be pickled, don't fret too much about it,
             # we'll format it ourselves instead.
             self._proxy.call_no_response(

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -50,15 +50,19 @@ class ProxyLoggingHandler(logging.Handler):
         if self._proxy.is_closed():
             return
 
+        msg = record.msg
+        if record.exc_info:
+            msg += "\n" + ''.join(traceback.format_tb(record.exc_info[2]))
+
         try:
             self._proxy.call_no_response(
-                "proxy_log", record.levelno, record.msg, record.args
+                "proxy_log", record.levelno, msg, record.args
             )
-        except Exception:
+        except Exception as e:
             # If something couldn't be pickled, don't fret too much about it,
             # we'll format it ourselves instead.
             self._proxy.call_no_response(
-                "proxy_log", record.levelno, (record.msg % record.args), []
+                "proxy_log", record.levelno, (msg % record.args), []
             )
 
 


### PR DESCRIPTION
Fixes an issue where `tk-desktop` would not log the exception information over the proxy.

This PR fixes it, although I'm not sure if it is the best approach. The `record.exc_info` can't be pickled, and therefore can't be passed as a separate arg for the `_proxy_log` method to deal with , so I opted for formatting the traceback and combining it with the `record.msg`.

Example where error was raised in a core hook:
```
2019-11-29 17:02:52,438 [15022 ERROR sgtk.ext.tkimp2a7afea3ef6949d9b67ed01e069df98c.tk_desktop.site_communication] [PROXY] Exception raised while executing hook '/sg_toolkit/philscad/configs/garden_show/core/hooks/context_change.py'
  File "/Users/philips1/Library/Caches/Shotgun/philscad/p89c1.basic.desktop/cfg/install/core/python/tank/pipelineconfig.py", line 1217, in execute_core_hook_method_internal
    return_value = hook.execute_hook_method(hook_paths, parent, method_name, **kwargs)
  File "/Users/philips1/Library/Caches/Shotgun/philscad/p89c1.basic.desktop/cfg/install/core/python/tank/hook.py", line 618, in execute_hook_method
    ret_val = hook_method(**kwargs)
  File "/sg_toolkit/philscad/configs/garden_show/core/hooks/context_change.py", line 65, in post_context_change
    raise Exception("bad things")
```
