### PR TITLE
Fixes a bug with closing a Python process

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -348,6 +348,10 @@ class DesktopEngineProjectImplementation(object):
             # Note any changes made here, should also be considered for the `ProxyLoggingHandler` class in the
             # bootstrap_utilities module.
 
+            # Do not send logs if the connection is closed!
+            if not self._project_comm.connected:
+                return
+
             # If we have exception details, we need to format these and combine them with the message, as the traceback
             # object can't be serialize and passed over the proxy.
             if record.exc_info:
@@ -364,7 +368,7 @@ class DesktopEngineProjectImplementation(object):
             except Exception:
                 # If something couldn't be pickled, don't fret too much about it,
                 # we'll format it ourselves instead.
-                self._proxy.call_no_response(
+                self._project_comm.call_no_response(
                     "proxy_log", record.levelno, (msg % record.args), []
                 )
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1477,7 +1477,7 @@ class DesktopWindow(SystrayWindow):
         Picks which pipeline configuration to be loaded based on user input or previously used
         pipeline settings.
 
-        :param list pipeline_configurations: List of dicionaries with keys 'id' and 'code'.
+        :param list pipeline_configurations: List of dictionaries with keys 'id' and 'code'.
         :param dict project: Project entity dictionary with key 'id'.
 
         :returns: The pipeline configuration that should be loaded, or None.


### PR DESCRIPTION
A regression in the last release introduced a bug where it errored when shutting down the project python process.
Also fixes a typo in a comment.

```
...
  File "/Users/philips1/source_code/tk-desktop/python/tk_desktop/desktop_engine_project_implementation.py", line 367, in _emit_log_message
    self._proxy.call_no_response(
AttributeError: 'DesktopEngineProjectImplementation' object has no attribute '_proxy'
```
There was a typo where it was calling `self._proxy` instead of `self._project_comm`.

Upon fixing that, it turned out it should also be checking if the `_project_comm` is still connected before trying to log.