### PR TITLE
Patched _proxy_log to be more useful

### DIFF
--- a/python/tk_desktop/site_communication.py
+++ b/python/tk_desktop/site_communication.py
@@ -73,7 +73,12 @@ class SiteCommunication(QtCore.QObject, CommunicationBase):
         :param args: Arguments to log.
         """
         try:
-            logger.log(level, "[PROXY] %s" % msg, *args)
+            # Format first so logger.exception can use it
+            msg = "[PROXY] %s" % msg
+            logger.log(level, msg, *args)
         except Exception:
-            logger.exception("Unexpected error when logging proxy message:")
-            raise
+            message = (
+                "Unexpected error when logging proxy message: "
+                'level:%s msg:"%s" args:%s'
+            )
+            logger.exception(message, level, msg, args)


### PR DESCRIPTION
### Problem
If proxy messages fail to log, the exception message logged does very little to help debug erroneous message formatting.

### Changed

- Report level, message and arguments when logging proxy message log failures   