### PR TITLE
SG-17545 pre v2.5.3 PySide fix

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -528,11 +528,11 @@ class DesktopWindow(SystrayWindow):
                 # GetDLLDirectory throws an exception if none was set
                 try:
                     self._previous_dll_directory = win32api.GetDllDirectory(None)
-                except StandardError:
+                except Exception:
                     self._previous_dll_directory = None
 
                 win32api.SetDllDirectory(None)
-            except StandardError:
+            except Exception:
                 log.warning("Could not push DllDirectory under Windows.")
 
     def _pop_dll_state(self):
@@ -544,7 +544,7 @@ class DesktopWindow(SystrayWindow):
                 import win32api
 
                 win32api.SetDllDirectory(self._previous_dll_directory)
-            except StandardError:
+            except Exception:
                 log.warning("Could not restore DllDirectory under Windows.")
 
     def register_tab(self, tab_name, tab_widget):

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1241,7 +1241,7 @@ class DesktopWindow(SystrayWindow):
                 "It appears you may still be running older components "
                 "that are not Python 3 compatible. We recommend you upgrade "
                 "to these versions or newer in your project:\n"
-                "- tk-desktop: v2.5.0+\n"
+                "- tk-desktop: v2.5.3+\n"
                 "- tk-framework-desktopserver: v1.3.10+"
             )
         else:

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -223,10 +223,10 @@ class Bootstrap(object):
         """
         # First try to see if PySide or PyQt4 exist in the current environment before attempting to patch sys modules.
         try:
-            import PySide
+            import PySide  # noqa
         except ImportError:
             try:
-                import PyQt4
+                import PyQt4  # noqa
             except ImportError:
                 # PySide and PyQt4 don't exist so we need to patch the sys.modules to
                 # add PySide2 as if it was PySide. This is so if we are using a

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -77,6 +77,12 @@ class ProxyLoggingHandler(logging.Handler):
             pass
 
 
+def _ensure_str(text):
+    if sys.version_info[0] == 2 and isinstance(text, unicode):
+        return str(text)
+    return text
+
+
 def _create_proxy(data):
     """
     Create a proxy based on the data received from the Shotgun Desktop.
@@ -88,7 +94,7 @@ def _create_proxy(data):
     # from the desktop due to write permissions on the folder.
     rpc_lib = imp.load_source("rpc", data["rpc_lib_path"])
     return rpc_lib.RPCProxy(
-        data["proxy_data"]["proxy_pipe"], data["proxy_data"]["proxy_auth"],
+        data["proxy_data"]["proxy_pipe"], data["proxy_data"]["proxy_auth"]
     )
 
 
@@ -123,6 +129,13 @@ class Bootstrap(object):
         import sgtk
 
         del os.environ["TANK_CURRENT_PC"]
+
+        self._raw_data["proxy_data"]["proxy_pipe"] = _ensure_str(
+            self._raw_data["proxy_data"]["proxy_pipe"]
+        )
+        self._raw_data["proxy_data"]["proxy_auth"] = _ensure_str(
+            self._raw_data["proxy_data"]["proxy_auth"]
+        )
 
         self._proxy = _create_proxy(self._raw_data)
         try:

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -232,6 +232,7 @@ class Bootstrap(object):
                 # add PySide2 as if it was PySide. This is so if we are using a
                 # pre v2.5.3 release of tk-desktop it will be able to import QT.
                 from sgtk.util.qt_importer import QtImporter
+
                 # Importing PySide2 and storing it in sys.modules causes "from PySide import QtCore" not to work.
                 # It import the unpatched version, so we import an empty python file to use as the package.
                 import PySide_patch


### PR DESCRIPTION
Adds a fix to allow projects that use a version of `tk-desktop` pre `v2.5.3` to load Qt based apps.

It does this by patching the PySide2 libraries to act as PySide, and then inserting them into `sys.modules`.
It only does this if PySide or PyQt4 don't already exist in the environment.