### PR TITLE
SG-17723 Fixes the styling issues with PySide2 around the project back button.

### DIFF
--- a/style.qss
+++ b/style.qss
@@ -70,7 +70,18 @@ QWidget
 
 #project_subheader QPushButton
 {
-    background-color: transparent;
+    /*Setting the border to 0 actually makes the background
+     transparent when pressed in. Where as
+     background-color: transparent; didn't work with PySide2 Fusion style.*/
+    border: 0px;
+}
+
+#project_subheader QPushButton:pressed {
+    /*Fusion styled UIs don't indent the button contents when pressed,
+     When combined with a transparent background there is not indication
+     of it being pressed, so this makes it indent.*/
+    margin-left: 2px;
+    margin-top: 2px;
 }
 
 #configuration_frame

--- a/style.qss
+++ b/style.qss
@@ -78,7 +78,7 @@ QWidget
 
 #project_subheader QPushButton:pressed {
     /*Fusion styled UIs don't indent the button contents when pressed,
-     When combined with a transparent background there is not indication
+     When combined with a transparent background there is no indication
      of it being pressed, so this makes it indent.*/
     margin-left: 2px;
     margin-top: 2px;


### PR DESCRIPTION
This fixes a styling issue on SG Desktop with PySide2 where pressing the back button on the project page, would cause a dark background on the button to appear. Where as with PySide (1) the icon would indent but the background wouldn't change. 

This also cause other visual oddities as there are two "spacer" buttons inserted on each side of the bar, which as far as I can see do nothing, but it meant these also when dark when pressed, where as before the user didn't know they were pressing them as there was no visual clue. I don't know why these buttons exist, it seems an actual spacer could have been used, but I didn't change this as I don't know the reasons behind it. The styling fix applies to them as well so they go back to being invisible.

Also it became apparent on fixing the background color that the icon no longer indents with the `fusion` style, like it did with the `plasitque` so I added a margin on pressed to fix that as well. This seems to override the behaviour in PySide (1) as well, so the behaviour is consistent.

