### PR TITLE
SG-17782 Adjusts some of the spacing between recent items.

### DIFF
--- a/python/tk_desktop/command_panel/recent_button.py
+++ b/python/tk_desktop/command_panel/recent_button.py
@@ -20,7 +20,7 @@ class RecentButton(QtGui.QPushButton):
     a single action, unlike the CommandButton.
     """
 
-    MARGIN = 5
+    MARGIN = 2
     SPACING = 5
     SIZER_LABEL = None
 
@@ -54,10 +54,13 @@ class RecentButton(QtGui.QPushButton):
         self.icon_label = QtGui.QLabel(self)
         self.icon_label.setAlignment(QtCore.Qt.AlignHCenter)
         self.layout().addWidget(self.icon_label, QtCore.Qt.AlignHCenter)
+        # setting the stretch to 0 on the icon means the the text label will
+        # stretch and the icon won't creating a more stable looking effect.
+        layout.setStretch(0, 0)
 
         self.text_label = QtGui.QLabel(parent)
         self.text_label.setWordWrap(True)
-        self.text_label.setAlignment(QtCore.Qt.AlignHCenter)
+        self.text_label.setAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignTop)
         self.layout().addWidget(self.text_label, QtCore.Qt.AlignHCenter)
 
         self.setFocusPolicy(QtCore.Qt.NoFocus)
@@ -97,16 +100,3 @@ class RecentButton(QtGui.QPushButton):
         Name of the command.
         """
         return self._command_name
-
-    def sizeHint(self):
-        """
-        Hint at the button size.
-
-        The button should occupy 1/MAX_RECENTS's of the parent widget width
-        and be a bit higher than the icon.
-        """
-        hint = QtCore.QSize(
-            (self.parentWidget().width() / MAX_RECENTS) - (self.SPACING * 2),
-            ICON_SIZE.height() + 8,
-        )
-        return hint

--- a/python/tk_desktop/command_panel/recent_list.py
+++ b/python/tk_desktop/command_panel/recent_list.py
@@ -90,5 +90,7 @@ class RecentList(BaseIconList):
         """
         for i in range(self._layout.count()):
             widget = self._layout.itemAt(i).widget()
+            # The widget will be None if the layout item was a spacer.
+            # If it is a spacer we can skip that as it is not technically a button.
             if widget:
                 yield widget

--- a/python/tk_desktop/command_panel/recent_list.py
+++ b/python/tk_desktop/command_panel/recent_list.py
@@ -22,7 +22,7 @@ class RecentList(BaseIconList):
 
     def __init__(self, parent):
         super(RecentList, self).__init__(parent, QtGui.QHBoxLayout())
-        self._layout.addStretch(1)
+        self._layout.setSpacing(3)
 
     def add_command(self, command_name, button_name, icon, tooltip, timestamp):
         """
@@ -38,7 +38,7 @@ class RecentList(BaseIconList):
 
         buttons = list(self.buttons)
 
-        # First seach if this button is already present. If it is, move it
+        # First search if this button is already present. If it is, move it
         # to the front.
         for button in buttons:
             # This button already exist. Make it the first button!
@@ -70,10 +70,9 @@ class RecentList(BaseIconList):
         button.command_triggered.connect(self.command_triggered)
         self._layout.insertWidget(insert_pos, button)
 
-        # If there are now more recents than we should have in the gui,
-        # drop the last one. - 1 applies here because the last item is
-        # the stretcher, which isn't a button.
-        if (self._layout.count() - 1) > MAX_RECENTS:
+        # If there are now more recents than we should have in the GUI,
+        # drop the last one.
+        if self._layout.count() > MAX_RECENTS:
             self._layout.takeAt(MAX_RECENTS).widget().deleteLater()
 
     @property
@@ -81,7 +80,5 @@ class RecentList(BaseIconList):
         """
         An iterator over the buttons in the list.
         """
-        # - 1 applies here because the last item is the stretcher, which isn't a
-        # button.
-        for i in range(self._layout.count() - 1):
+        for i in range(self._layout.count()):
             yield self._layout.itemAt(i).widget()

--- a/python/tk_desktop/command_panel/recent_list.py
+++ b/python/tk_desktop/command_panel/recent_list.py
@@ -47,8 +47,7 @@ class RecentList(BaseIconList):
         # to the front.
         for button in buttons:
             # If this button already exists. Make it the first button!
-            # The button will be None if it is a placeholder stretcher
-            if button and button.command_name == command_name:
+            if button.command_name == command_name:
                 self._layout.removeWidget(button)
                 self._layout.insertWidget(0, button)
                 return
@@ -58,7 +57,7 @@ class RecentList(BaseIconList):
         for idx, button in enumerate(buttons):
             # The timestamp of the command we're inserting is more recent
             # than the current command, so we're inserting the command before.
-            if button is None or timestamp >= button.timestamp:
+            if timestamp >= button.timestamp:
                 insert_pos = idx
                 break
         else:
@@ -90,4 +89,6 @@ class RecentList(BaseIconList):
         An iterator over the buttons in the list.
         """
         for i in range(self._layout.count()):
-            yield self._layout.itemAt(i).widget()
+            widget = self._layout.itemAt(i).widget()
+            if widget:
+                yield widget


### PR DESCRIPTION
The recent items list was cropping some of the text on the items depending on the size of the window when you opened the project. This is it in an extreme state where the window was really small when clicking on the project, and then expanded after loading.
<img width="763" alt="Shotgun" src="https://user-images.githubusercontent.com/3777228/84165225-5c996200-aa6b-11ea-9915-2c9981de6461.png">

This fix does the following:
- Makes the buttons stretch out as the window stretches rather than keeping them fixed.
- Makes the text stay aligned to the top, so that it doesn't display at varying heights when the text for some buttons goes onto multiple lines.
- Reduces the spacing between the buttons slightly (by 1px) so that the impact of having a smaller window is slightly reduced on the cropping.

In summary the cropping of text still happens, but it is less severe, and expanding the window allows the items have enough room to show all their text.
I tested in the PySide2 and PySide builds of desktop.
A video of this in action can be found on the internal ticket.

<img width="727" alt="Shotgun" src="https://user-images.githubusercontent.com/3777228/84165755-f5c87880-aa6b-11ea-83a4-1ec5ce9df753.png">
