### PR TITLE
SG:18139: Python version in about box.

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -18,6 +18,7 @@ import pprint
 import inspect
 import re
 from collections import OrderedDict
+from distutils.version import LooseVersion
 
 
 from tank.platform.qt import QtCore, QtGui
@@ -1652,12 +1653,14 @@ class DesktopWindow(SystrayWindow):
         # we have a startup version to show.
 
         versions = OrderedDict()
-        versions["App Version"] = engine.app_version
+        versions["App"] = engine.app_version
+        if engine.app_version >= LooseVersion("v1.6.0"):
+            versions["Python"] = "{}.{}.{}".format(*sys.version_info[0:3])
 
         if engine.startup_version:
-            versions["Startup Version"] = engine.startup_version
+            versions["Startup"] = engine.startup_version
 
-        versions["Engine Version"] = engine.version
+        versions["Engine"] = engine.version
         versions["Core"] = engine.sgtk.version
 
         if engine.sgtk.configuration_descriptor:

--- a/python/tk_desktop/ui/about_screen.py
+++ b/python/tk_desktop/ui/about_screen.py
@@ -11,7 +11,7 @@ from sgtk.platform.qt import QtCore, QtGui
 class Ui_AboutScreen(object):
     def setupUi(self, AboutScreen):
         AboutScreen.setObjectName("AboutScreen")
-        AboutScreen.resize(320, 358)
+        AboutScreen.resize(320, 388)
         AboutScreen.setMinimumSize(QtCore.QSize(320, 327))
         self.verticalLayout = QtGui.QVBoxLayout(AboutScreen)
         self.verticalLayout.setSpacing(15)

--- a/python/tk_desktop/ui/resources_rc.py
+++ b/python/tk_desktop/ui/resources_rc.py
@@ -2,7 +2,7 @@
 
 # Resource object code
 #
-#      by: The Resource Compiler for PySide (Qt v4.8.7)
+#      by: The Resource Compiler for PySide (Qt v4.8.6)
 #
 # WARNING! All changes made in this file will be lost!
 

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -133,7 +133,7 @@ def _env_not_set_or_split(var_name):
         return "Not Set"
     else:
         # Add a \n before the first item so each item in the output start from the
-        # beginning of the time. Otherwise you'd get.
+        # beginning of the line. Otherwise you'd get.
         # varname: - one
         # - two
         # - three.

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -109,17 +109,41 @@ def _ensure_no_unicode(obj):
 
 
 def _enumerate_per_line(items):
+    """
+    Enumerate all items from an array, one line at a time.
+
+    For example,
+        - one
+        - two
+        - three
+
+    :returns: The formatted output.
+    """
     return "\n".join("- {}".format(item) for item in items)
 
 
 def _env_not_set_or_split(var_name):
+    """
+    Format a PATH-like environment variable for output.
+
+    :param str var_name: Name of the env var.
+    :returns: "Not Set" if variable is not set, a bullet list otherwise.
+    """
     if var_name not in os.environ:
         return "Not Set"
     else:
+        # Add a \n before the first item so each item in the output start from the
+        # beginning of the time. Otherwise you'd get.
+        # varname: - one
+        # - two
+        # - three.
         return "\n" + _enumerate_per_line(os.environ[var_name].split(os.path.pathsep))
 
 
 def _log_startup_information():
+    """
+    Log information about the Python subprocess that was just started.
+    """
     import sgtk
 
     logger = sgtk.LogManager.get_logger(__file__)

--- a/resources/about_screen.ui
+++ b/resources/about_screen.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>320</width>
-    <height>358</height>
+    <height>388</height>
    </rect>
   </property>
   <property name="minimumSize">


### PR DESCRIPTION
The about box now shows the Python version, only if the build supports both Python 2 and 3. 
![Screen Shot 2020-06-29 at 13 29 21](https://user-images.githubusercontent.com/8126447/86042456-2d946180-ba15-11ea-905b-348de77429a7.png)

As for the logging, it looks like this:

```
Python
======
Executable: /Applications/Shotgun.app/Contents/MacOS/Shotgun
Version: 2.7.17
sys.path:
- /Users/boismej/gitlocal/tk-framework-desktopstartup/python
- /Applications/Shotgun.app/Contents/Resources/Desktop/Python
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python27.zip
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/plat-darwin
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/plat-mac
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/plat-mac/lib-scriptpackages
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/lib-tk
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/lib-old
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/lib-dynload
- /Users/boismej/.local/lib/python2.7/site-packages
- /Users/boismej/gitlocal/mpas-ma
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/site-packages
Environment variables
=====================
PATH: 
- /usr/local/opt/tcl-tk/bin
- /Users/boismej/.cargo/bin
- /Users/boismej/.rvm/gems/ruby-2.7.0/bin
- /Users/boismej/.rvm/gems/ruby-2.7.0@global/bin
- /Users/boismej/.rvm/rubies/ruby-2.7.0/bin
- /usr/local/Cellar/pyenv-virtualenv/1.1.3/shims
- /Users/boismej/.pyenv/shims
- /usr/local/bin
- /usr/bin
- /bin
- /usr/sbin
- /sbin
- /Applications/VMware Fusion.app/Contents/Public
- /Library/Frameworks/Mono.framework/Versions/Current/Commands
- /Users/boismej/.rvm/bin
- /Users/boismej/.rvm/bin
PYTHONHOME: Not Set
PYTHONPATH: Not Set
```
