### PR TITLE
SG-17970 Fixes recent items not showing.

### DIFF
--- a/python/tk_desktop/command_panel/command_panel.py
+++ b/python/tk_desktop/command_panel/command_panel.py
@@ -189,7 +189,7 @@ class CommandPanel(QtGui.QWidget):
         # Python 2.7.
         command_name = six.ensure_str(command_name)
 
-        self._recents[command_name] = {"timestamp": datetime.now()}
+        self._recents[command_name] = {"timestamp": datetime.utcnow()}
         self._store_recents()
         self._refresh_recent_list(command_name)
         self._restrict_recent_buttons(self._get_optimal_width())


### PR DESCRIPTION
Recent items were not being stored when in Python 3 due to the way we were trying to pickle the datetime objects before saving them with `QSettings`.

I looked into applying the fix at the shotgunutils side, and whilst it was possible there were other complications and things to consider. In the end it was simpler to store string representations of the datetime instead.

This code handles loading both datetime object and string dates which it then converts back into datetime objects for use during run time.

You will get an error if you downgrade desktop as the old desktop will not know how to handle the string format. However this error is largely silent, it only appears to show if you launched from a terminal, and the rest of the recents items that weren't stored with a string format do show up.