### PR TITLE
SG-13270: adminui in python3

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -161,7 +161,7 @@ requires_shotgun_version:
 requires_core_version: "v0.19.5"
 
 frameworks:
-    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.8.0"}
-    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.1.0"}
-    - {"name": "tk-framework-adminui", "version": "v0.x.x"}
+    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.9.0"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.7.1"}
+    - {"name": "tk-framework-adminui", "version": "v0.x.x", "minimum_version": "v0.6.0"}
     - {"name": "tk-framework-desktopserver", "version": "v1.x.x", "minimum_version": "v1.2.0"}

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -38,9 +38,7 @@ from .systray import SystrayWindow
 from .about_screen import AboutScreen
 from .no_apps_installed_overlay import NoAppsInstalledOverlay
 
-# This only works in Python 2 for now.
-if six.PY2:
-    from .setup_project import SetupProject
+from .setup_project import SetupProject
 from .setup_new_os import SetupNewOS
 from .project_model import SgProjectModel
 from .project_model import SgProjectModelProxy
@@ -192,9 +190,8 @@ class DesktopWindow(SystrayWindow):
         self.project_overlay = LoadingProjectWidget(self._command_panel)
         self.install_apps_widget = NoAppsInstalledOverlay(self._command_panel)
         # setup project does not work on Python 3 yet.
-        if six.PY2:
-            self.setup_project_widget = SetupProject(self._command_panel)
-            self.setup_project_widget.setup_finished.connect(self._on_setup_finished)
+        self.setup_project_widget = SetupProject(self._command_panel)
+        self.setup_project_widget.setup_finished.connect(self._on_setup_finished)
         self.update_project_config_widget = UpdateProjectConfig(self._command_panel)
         self.update_project_config_widget.update_finished.connect(
             self._on_update_finished
@@ -1086,10 +1083,7 @@ class DesktopWindow(SystrayWindow):
         # hide the pipeline configuration bar
         self.ui.configuration_frame.hide()
 
-        # hide the setup project ui if it is shown
-        # setup project does not work on Python 3
-        if six.PY2:
-            self.setup_project_widget.hide()
+        self.setup_project_widget.hide()
         self.update_project_config_widget.hide()
         self.setup_new_os_widget.hide()
         self.install_apps_widget.hide()
@@ -1349,16 +1343,13 @@ class DesktopWindow(SystrayWindow):
             ):
                 # If we have the new Shotgun that supports zero config, add the setup project entry in the menu
                 if self.__get_server_version(engine.shotgun) >= (7, 2, 0):
-                    # The admin UI does not work in Python 3 for now.
-                    self.ui.actionAdvanced_Project_Setup.setVisible(six.PY2)
+                    self.ui.actionAdvanced_Project_Setup.setVisible(True)
                 else:
                     # Otherwise hide the entry and provide the same old experience as before and quit, as we can't
                     # bootstrap.
                     self.ui.actionAdvanced_Project_Setup.setVisible(False)
-                    # setup project does not work on Python 3 yet.
-                    if six.PY2:
-                        self.setup_project_widget.project = project
-                        self.setup_project_widget.show()
+                    self.setup_project_widget.project = project
+                    self.setup_project_widget.show()
                     # Stop here, we don't want to launch Python at this point.
                     return
             else:

--- a/python/tk_desktop/setup_project.py
+++ b/python/tk_desktop/setup_project.py
@@ -41,13 +41,7 @@ class SetupProject(QtGui.QWidget):
         self.setVisible(False)
 
     def do_setup(self, show_help=False):
-        # Only toggle top window if it used to be off (to avoid un-necessary window flicker in case it was already off)
-        is_on_top = self._is_on_top()
-
         try:
-            if is_on_top:
-                self._set_top_window_on_top(False)
-
             # First check to see if the current user
             self._validate_user_permissions()
 
@@ -78,10 +72,6 @@ class SetupProject(QtGui.QWidget):
                 % self.project["name"],
             )
             error_dialog.exec_()
-
-        finally:
-            if is_on_top:
-                self._set_top_window_on_top(True)
 
     def show_help_popup(self):
         """
@@ -134,39 +124,6 @@ class SetupProject(QtGui.QWidget):
 
             # Raise any other general Exceptions.
             raise
-
-    def _is_on_top(self):
-        """
-        Check if top window is always on top
-        :returns: True if top window is always on top
-        """
-        is_on_top = False
-
-        flags = self.window().windowFlags()
-        is_on_top = (
-            flags & QtCore.Qt.WindowStaysOnTopHint
-        ) == QtCore.Qt.WindowStaysOnTopHint
-
-        return is_on_top
-
-    def _set_top_window_on_top(self, state):
-        """
-        Set always on top setting for top window.
-        Since Qt re-parents when changing this flag, the window gets back behind everything,
-        therefore we also need to bring it back to the front when toggling the state.
-
-        :param state: Boolean Whether to set the window always on top or not.
-        """
-        flags = self.window().windowFlags()
-
-        if state:
-            self.window().setWindowFlags(flags | QtCore.Qt.WindowStaysOnTopHint)
-        else:
-            self.window().setWindowFlags(flags & ~QtCore.Qt.WindowStaysOnTopHint)
-
-        self.window().show()
-        self.window().raise_()
-        self.window().activateWindow()
 
     def _on_parent_resized(self):
         """


### PR DESCRIPTION
Reactivates the admin UI in Python 3.

I've also removed code that broke the admin UI on Linux and Windows with PySide2 and which wasn't required with PySide 1. Less code, good!