### PR TITLE
SG-16894 Enable browser integration for python3

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -162,6 +162,6 @@ requires_core_version: "v0.19.5"
 
 frameworks:
     - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.9.0"}
-    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.1.0"}
-    - {"name": "tk-framework-adminui", "version": "v0.x.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.7.1"}
+    - {"name": "tk-framework-adminui", "version": "v0.x.x", "minimum_version": "v0.6.0"}
     - {"name": "tk-framework-desktopserver", "version": "v1.x.x", "minimum_version": "v1.4.0"}

--- a/info.yml
+++ b/info.yml
@@ -164,4 +164,4 @@ frameworks:
     - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.8.0"}
     - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.1.0"}
     - {"name": "tk-framework-adminui", "version": "v0.x.x"}
-    - {"name": "tk-framework-desktopserver", "version": "v1.x.x", "minimum_version": "v1.2.0"}
+    - {"name": "tk-framework-desktopserver", "version": "v1.x.x", "minimum_version": "v1.4.0"}

--- a/info.yml
+++ b/info.yml
@@ -161,7 +161,7 @@ requires_shotgun_version:
 requires_core_version: "v0.19.5"
 
 frameworks:
-    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.8.0"}
+    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.9.0"}
     - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.1.0"}
     - {"name": "tk-framework-adminui", "version": "v0.x.x"}
     - {"name": "tk-framework-desktopserver", "version": "v1.x.x", "minimum_version": "v1.4.0"}

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -477,7 +477,7 @@ class DesktopEngineSiteImplementation(object):
         # Note that the server argument is set regardless of whether the server launched or crashed,
         # so we have to actually get its value instead of merely checking for existence.
         # Note: browser integration is not supported when running Python 3 inside Desktop.
-        if server is None and six.PY2:
+        if server is None:
             # Initialize all of this after the style-sheet has been applied so any prompt are also
             # styled after the Shotgun Desktop's visual-style.
             if splash:


### PR DESCRIPTION
This removes the check that only allows browser integration for Python2. It also bumps the minimum version for the desktopserver requirement to the version that supports Python3