### PR TITLE
SG-18277 Engine's destroy method not called

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -319,7 +319,7 @@ class DesktopEngineProjectImplementation(object):
         :param app: QApplication instance.
         """
         # Make sure we shut down cleanly.
-        app.aboutToQuit.connect(self._engine.destroy_engine)
+        app.aboutToQuit.connect(self._engine.destroy)
 
     @property
     def connected(self):

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -514,7 +514,7 @@ class DesktopEngineSiteImplementation(object):
         self._run_startup_commands()
 
         # make sure we close down our rpc threads
-        app.aboutToQuit.connect(self._engine.destroy_engine)
+        app.aboutToQuit.connect(self._engine.destroy)
 
         # and run the app
         result = app.exec_()


### PR DESCRIPTION
In the tk-desktop engine implementations we are calling `destory_engine()` directly instead of calling `destroy()` and letting it call `destroy_engine()`. As a result, a lot of the normal shut down procedures are not being called. 

This solves the problem in the ticket that the `destroy_app()` method on apps was not being called. The other thing mentioned in the ticket was that `closeEvent` is not called on the widget. This fix does not solve that problem. 