### PR TITLE
SG-18612 fix for no keyboard input on mac

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -189,7 +189,7 @@ class DesktopEngineProjectImplementation(object):
             # will steal focus from any currently focused application.
             # We set the application to use `LSUIElement=1` so that it stays in the background in start_app().
             # However we need to bring it to the foreground when we want to run an app.
-            # This solution for bring it back to the foreground is a modification of the example here:
+            # This solution for bringing it back to the foreground is a modification of the example here:
             # https://stackoverflow.com/a/34381136/4223964
             try:
                 import AppKit

--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -183,6 +183,29 @@ class DesktopEngineProjectImplementation(object):
 
     def _trigger_callback(self, namespace, command, *args, **kwargs):
         callback = self.__callback_map.get((namespace, command))
+
+        if sgtk.util.is_macos():
+            # If we are on Mac with PySide2, then starting a QApplication even with no Windows
+            # will steal focus from any currently focused application.
+            # We set the application to use `LSUIElement=1` so that it stays in the background in start_app().
+            # However we need to bring it to the foreground when we want to run an app.
+            # This solution for bring it back to the foreground is a modification of the example here:
+            # https://stackoverflow.com/a/34381136/4223964
+            try:
+                import AppKit
+
+                info = AppKit.NSBundle.mainBundle().infoDictionary()
+                # Setting it to 0 will bring the application back to the foreground.
+                info["LSUIElement"] = "0"
+                AppKit.NSApp.setActivationPolicy_(
+                    AppKit.NSApplicationActivationPolicyRegular
+                )
+            except ImportError:
+                # Since AppKit is bundled with the Desktop installer, it's possible we are using
+                # an older version of the installer that doesn't contain this package. In which
+                # case just move on silently.
+                pass
+
         try:
             callback(*args, **kwargs)
         except Exception:
@@ -283,7 +306,7 @@ class DesktopEngineProjectImplementation(object):
                 import AppKit
 
                 info = AppKit.NSBundle.mainBundle().infoDictionary()
-                info["LSBackgroundOnly"] = "1"
+                info["LSUIElement"] = "1"
             except ImportError:
                 # Since AppKit is bundled with the Desktop installer, it's possible we are using
                 # an older version of the installer that doesn't contain this package. In which


### PR DESCRIPTION
Fixes an issue that was introduced with the fix for the project `QApplication` stealing focus on Mac.

That fix introduced an an issue where the keyboard input couldn't be registered with any of the launched apps. This was because the `QApplication` was permanently in the background.

The fix is to now move it to the foreground when we run an app.