### PR TITLE
SG-18905: Site switching fix

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -944,12 +944,10 @@ class DesktopWindow(SystrayWindow):
 
             dialog = BrowserIntegrationUserSwitchDialog(msg, self)
 
-            # The following applies to macOS only and has no side-effect on other plaforms.
-            # If the dialog is pinned, it means it is also in background. We'll bring the app to the foreground
-            # so keyboard focus is granted automatically to the BrowserIntegrationUserSwitchDialog instead
-            # of being unfocussed.
-            if self.is_pinned():
-                osutils.make_app_foreground()
+            # The following applies to macOS only and has no side-effect on other platforms.
+            # Making the app the foreground app on macOS ensure it gets the focus. Other platforms
+            # just work without this call.
+            osutils.make_app_foreground()
 
             dialog.exec_()
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -65,7 +65,6 @@ overlay_widget = sgtk.platform.import_framework(
     "tk-framework-qtwidgets", "overlay_widget"
 )
 settings = sgtk.platform.import_framework("tk-framework-shotgunutils", "settings")
-# This framework is not compatible with Python 3 at the moment.
 desktop_server_framework = sgtk.platform.get_framework("tk-framework-desktopserver")
 
 ShotgunModel = shotgun_model.ShotgunModel
@@ -274,7 +273,6 @@ class DesktopWindow(SystrayWindow):
 
         advanced_menu.addAction(self.toggle_debug_action)
 
-        # This framework is not compatible with Python 3 at the moment
         if (
             desktop_server_framework.can_run_server()
             and desktop_server_framework.can_regenerate_certificates()
@@ -364,7 +362,6 @@ class DesktopWindow(SystrayWindow):
             self.handle_project_thumbnail_updated
         )
 
-        # This framework is not compatible with Python 3 at the moment.
         desktop_server_framework.add_different_user_requested_callback(
             self._on_different_user
         )

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -66,8 +66,7 @@ overlay_widget = sgtk.platform.import_framework(
 )
 settings = sgtk.platform.import_framework("tk-framework-shotgunutils", "settings")
 # This framework is not compatible with Python 3 at the moment.
-if six.PY2:
-    desktop_server_framework = sgtk.platform.get_framework("tk-framework-desktopserver")
+desktop_server_framework = sgtk.platform.get_framework("tk-framework-desktopserver")
 
 ShotgunModel = shotgun_model.ShotgunModel
 
@@ -277,8 +276,7 @@ class DesktopWindow(SystrayWindow):
 
         # This framework is not compatible with Python 3 at the moment
         if (
-            six.PY2
-            and desktop_server_framework.can_run_server()
+            desktop_server_framework.can_run_server()
             and desktop_server_framework.can_regenerate_certificates()
         ):
             advanced_menu.addAction(self.ui.actionRegenerate_Certificates)
@@ -367,10 +365,9 @@ class DesktopWindow(SystrayWindow):
         )
 
         # This framework is not compatible with Python 3 at the moment.
-        if six.PY2:
-            desktop_server_framework.add_different_user_requested_callback(
-                self._on_different_user
-            )
+        desktop_server_framework.add_different_user_requested_callback(
+            self._on_different_user
+        )
 
         # Set of sites that are being ignored when browser integration requests happen. This set is not
         # persisted when the desktop is closed.

--- a/python/tk_desktop/extensions/darwin_python2/__init__.py
+++ b/python/tk_desktop/extensions/darwin_python2/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from . import osutils

--- a/python/tk_desktop/extensions/darwin_python2/__init__.py
+++ b/python/tk_desktop/extensions/darwin_python2/__init__.py
@@ -8,4 +8,4 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from . import osutils
+from . import osutils  # noqa

--- a/python/tk_desktop/extensions/darwin_python3/__init__.py
+++ b/python/tk_desktop/extensions/darwin_python3/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from . import osutils

--- a/python/tk_desktop/extensions/darwin_python3/__init__.py
+++ b/python/tk_desktop/extensions/darwin_python3/__init__.py
@@ -8,4 +8,4 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from . import osutils
+from . import osutils  # noqa

--- a/python/tk_desktop/extensions/linux_python2_qt4/__init__.py
+++ b/python/tk_desktop/extensions/linux_python2_qt4/__init__.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # import Qt to force the proper dependencies of osutils
-from sgtk.platform.qt import QtGui
-from sgtk.platform.qt import QtCore
+from sgtk.platform.qt import QtGui  # noqa
+from sgtk.platform.qt import QtCore  # noqa
 
-from . import osutils
+from . import osutils  # noqa


### PR DESCRIPTION
When another site tries to connect to browser integration in Shotgun Desktop, the site switching dialog did not appear in Python 3. This was because the site switching code had been disabled back when the browser integration was not Python 3 compatible, but we forgot to turn it back on. So now it is.

I also noticed an issue where the site switching dialog would not be focussed on macOS. Turns out we were importing a module from a directory without a `__init__.py` on macOS, so I've added it. On Linux the the `__init__.py` file was present and on Windows there is no extension module to load.