### PR TITLE
SG-19710 Fixes error loading console position and size.

### DIFF
--- a/python/tk_desktop/console.py
+++ b/python/tk_desktop/console.py
@@ -90,8 +90,13 @@ class Console(QtGui.QDialog):
             "console.size", QtCore.QSize(800, 400), self._settings_manager.SCOPE_GLOBAL
         )
 
-        self.move(pos)
-        self.resize(size)
+        try:
+            self.move(pos)
+            self.resize(size)
+        except TypeError:
+            # Its possible that we've loaded a PySide value,
+            # when we are using PySide2, in which case just ignore the setting.
+            pass
 
         self.__console_handler = ConsoleLogHandler(self)
         sgtk.LogManager().initialize_custom_handler(self.__console_handler)


### PR DESCRIPTION
I came across an issue on my Windows VM, where it was loading an old position setting value created in PySide, and trying to pass it to a PySide2 method, which errored and caused desktop not to start.
Normally the loading of the value in the settings manager would fail and the settings manager would gracefully handle it and return the default value. However there seemed to be something different about my vm setup that caused it to be able to load the old PySide value, and so an error was raised.

I didn't get to the bottom of what was different on my machine, but potentially this might happen to others, so it seemed better to fix it anyway.