### PR TITLE
SG-19789 Update licensing

### DIFF
--- a/python/tk_desktop/licenses.html
+++ b/python/tk_desktop/licenses.html
@@ -744,6 +744,77 @@
     </p>
 </div>
 
+<!--        enum34-->
+<div>
+    <p><strong>enum34</strong></p>
+    <p>Copyright (c) 2013, Ethan Furman.<br/>
+        All rights reserved.</p>
+
+    <p>Redistribution and use in source and binary forms, with or without<br/>
+        modification, are permitted provided that the following conditions<br/>
+        are met:</p>
+
+    <p> Redistributions of source code must retain the above<br/>
+        copyright notice, this list of conditions and the<br/>
+        following disclaimer.</p>
+
+    <p> Redistributions in binary form must reproduce the above<br/>
+        copyright notice, this list of conditions and the following<br/>
+        disclaimer in the documentation and/or other materials<br/>
+        provided with the distribution.</p>
+
+    <p> Neither the name Ethan Furman nor the names of any<br/>
+        contributors may be used to endorse or promote products<br/>
+        derived from this software without specific prior written<br/>
+        permission.</p>
+
+    <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"<br/>
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE<br/>
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE<br/>
+        ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE<br/>
+        LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR<br/>
+        CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF<br/>
+        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS<br/>
+        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN<br/>
+        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)<br/>
+        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE<br/>
+        POSSIBILITY OF SUCH DAMAGE.<br/>
+    </p>
+</div>
+
+<!--        Cryptography-->
+<div>
+    <p><strong>Cryptography</strong></p>
+
+    <p>Copyright (c) Individual contributors.<br/>
+        All rights reserved.</p>
+
+    <p>Redistribution and use in source and binary forms, with or without<br/>
+        modification, are permitted provided that the following conditions are met:</p>
+
+    <p> 1. Redistributions of source code must retain the above copyright notice,<br/>
+        this list of conditions and the following disclaimer.</p>
+
+    <p> 2. Redistributions in binary form must reproduce the above copyright<br/>
+        notice, this list of conditions and the following disclaimer in the<br/>
+        documentation and/or other materials provided with the distribution.</p>
+
+    <p> 3. Neither the name of PyCA Cryptography nor the names of its contributors<br/>
+        may be used to endorse or promote products derived from this software<br/>
+        without specific prior written permission.</p>
+
+    <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND<br/>
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED<br/>
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE<br/>
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR<br/>
+        ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES<br/>
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;<br/>
+        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON<br/>
+        ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT<br/>
+        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS<br/>
+        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+</div>
+
 <!--        six-->
 <div>
     <p><strong>six</strong></p>

--- a/python/tk_desktop/licenses.html
+++ b/python/tk_desktop/licenses.html
@@ -1,464 +1,964 @@
 <html xmlns="http://www.w3.org/1999/html">
-    <body>
-        <p><strong>Shotgun Desktop &copy; 2020 Autodesk, Inc. All rights reserved.</strong></p>
-        <p>
-            <strong>All use of this Software is subject to the Autodesk terms of service accepted upon access or use of this Service or made available on the Autodesk webpage. Autodesk terms of service for Autodesk's various web services can be found <a href="https://www.autodesk.com/company/legal-notices-trademarks/terms-of-service-autodesk360-web-services">here</a>.</strong>
-        </p>
-        <p>
-            <strong>Privacy</strong><br/>To learn more about Autodesk's online and offline privacy practices, please see the <a href="http://www.autodesk.com/company/legal-notices-trademarks/privacy-statement">Autodesk Privacy Statement</a>.
-        </p>
-        <p>
-            <strong>Autodesk Trademarks</strong><br/>The trademarks on the <a href="http://www.autodesk.com/company/legal-notices-trademarks/trademarks/autodesk-inc">Autodesk Trademarks page</a> are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in the USA and/or other countries. &nbsp;&nbsp;All other brand names, product names or trademarks belong to their respective holders.
-        </p>
-        <p>
-            <strong>Patents</strong><br/>This Service is protected by patents listed on the <a href="https://www.autodesk.com/company/legal-notices-trademarks/patents">Autodesk Patents page</a>.
-        </p>
-        <p>
-            <strong>Autodesk Cloud and Desktop Components</strong><br/> This Service may incorporate or use background Autodesk online and desktop technology components. For information about these components, see <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cloud-platform-components">Autodesk Cloud Platform Components</a> and <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components">Autodesk Desktop Platform Components</a>.
-        </p>
-        <p>
-            <strong>Third-Party Trademarks, Software Credits and Attributions</strong>
-        </p>
-
-        <!--        Python 2.7-->
-        <p><strong>Python 2.7</strong></p>
-        <p>1. This LICENSE AGREEMENT is between the Python Software Foundation (&quot;PSF&quot;), and<br>
-         the Individual or Organization (&quot;Licensee&quot;) accessing and otherwise using Python<br>
-         2.7.17 software in source or binary form and its associated documentation.</p>
-
-        <p>2. Subject to the terms and conditions of this License Agreement, PSF hereby<br>
-         grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,<br>
-         analyze, test, perform and/or display publicly, prepare derivative works,<br>
-         distribute, and otherwise use Python 2.7.17 alone or in any derivative<br>
-         version, provided, however, that PSF's License Agreement and PSF's notice of<br>
-         copyright, i.e., &quot;Copyright &copy; 2001-2020 Python Software Foundation; All Rights<br>
-         Reserved&quot; are retained in Python 2.7.17 alone or in any derivative version<br>
-         prepared by Licensee.</p>
-
-        <p>3. In the event Licensee prepares a derivative work that is based on or<br>
-         incorporates Python 2.7.17 or any part thereof, and wants to make the<br>
-         derivative work available to others as provided herein, then Licensee hereby<br>
-         agrees to include in any such work a brief summary of the changes made to Python<br>
-         2.7.17.</p>
-
-        <p>4. PSF is making Python 2.7.17 available to Licensee on an &quot;AS IS&quot; basis.<br>
-         PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF<br>
-         EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR<br>
-         WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE<br>
-         USE OF PYTHON 2.7.17 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.</p>
-
-        <p>5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 2.7.17<br>
-         FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF<br>
-         MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 2.7.17, OR ANY DERIVATIVE<br>
-         THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.</p>
-
-        <p>6. This License Agreement will automatically terminate upon a material breach of<br>
-         its terms and conditions.</p>
-
-        <p>7. Nothing in this License Agreement shall be deemed to create any relationship<br>
-         of agency, partnership, or joint venture between PSF and Licensee. This License<br>
-         Agreement does not grant permission to use PSF trademarks or trade name in a<br>
-         trademark sense to endorse or promote products or services of Licensee, or any<br>
-         third party.</p>
-
-        <p>8. By copying, installing or otherwise using Python 2.7.17, Licensee agrees<br>
-         to be bound by the terms and conditions of this License Agreement.</p>
-
-        <!--        Python 3.7-->
-        <p><strong>Python 3.7</strong></p>
-        <p>1. This LICENSE AGREEMENT is between the Python Software Foundation (&quot;PSF&quot;), and<br>
-         the Individual or Organization (&quot;Licensee&quot;) accessing and otherwise using Python<br>
-         3.7.6 software in source or binary form and its associated documentation.</p>
-
-        <p>2. Subject to the terms and conditions of this License Agreement, PSF hereby<br>
-         grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,<br>
-         analyze, test, perform and/or display publicly, prepare derivative works,<br>
-         distribute, and otherwise use Python 3.7.6 alone or in any derivative<br>
-         version, provided, however, that PSF's License Agreement and PSF's notice of<br>
-         copyright, i.e., &quot;Copyright &copy; 2001-2020 Python Software Foundation; All Rights<br>
-         Reserved&quot; are retained in Python 3.7.6 alone or in any derivative version<br>
-         prepared by Licensee.</p>
-
-        <p>3. In the event Licensee prepares a derivative work that is based on or<br>
-         incorporates Python 3.7.6 or any part thereof, and wants to make the<br>
-         derivative work available to others as provided herein, then Licensee hereby<br>
-         agrees to include in any such work a brief summary of the changes made to Python<br>
-         3.7.6.</p>
-
-        <p>4. PSF is making Python 3.7.6 available to Licensee on an &quot;AS IS&quot; basis.<br>
-         PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF<br>
-         EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR<br>
-         WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE<br>
-         USE OF PYTHON 3.7.6 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.</p>
-
-        <p>5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.7.6<br>
-         FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF<br>
-         MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.7.6, OR ANY DERIVATIVE<br>
-         THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.</p>
-
-        <p>6. This License Agreement will automatically terminate upon a material breach of<br>
-         its terms and conditions.</p>
-
-        <p>7. Nothing in this License Agreement shall be deemed to create any relationship<br>
-         of agency, partnership, or joint venture between PSF and Licensee. This License<br>
-         Agreement does not grant permission to use PSF trademarks or trade name in a<br>
-         trademark sense to endorse or promote products or services of Licensee, or any<br>
-         third party.</p>
-
-        <p>8. By copying, installing or otherwise using Python 3.7.6, Licensee agrees<br>
-         to be bound by the terms and conditions of this License Agreement.</p>
-
-        <!--        PySide2-->
-        <p><strong>PySide2:</strong></p>
-        <p>PySide is licensed under the LGPL version 2.1 license, allowing both Free/Open source software and proprietary software development.</p>
-
-        <p>GNU LESSER GENERAL PUBLIC LICENSE Version 2.1, February 1999</p>
-
-        <p>Copyright (C) 1991, 1999 Free Software Foundation, Inc. 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.</p>
-
-        <p>[This is the first released version of the Lesser GPL. It also counts as the successor of the GNU Library Public License, version 2, hence the version number 2.1.] Preamble The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.</p>
-
-        <p>This license, the Lesser General Public License, applies to some specially designated software packages--typically libraries--of the Free Software Foundation and other authors who decide to use it. You can use it too, but we suggest you first think carefully about whether this license or the ordinary General Public License is the better strategy to use in any particular case, based on the explanations below.</p>
-
-        <p>When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things.</p>
-
-        <p>To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it.</p>
-
-        <p>For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. And you must show them these terms so they know their rights.</p>
-
-        <p>We protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this license, which gives you legal permission to copy, distribute and/or modify the library.</p>
-
-        <p>To protect each distributor, we want to make it very clear that there is no warranty for the free library. Also, if the library is modified by someone else and passed on, the recipients should know that what they have is not the original version, so that the original author's reputation will not be affected by problems that might be introduced by others.</p>
-
-        <p>Finally, software patents pose a constant threat to the existence of any free program. We wish to make sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a patent holder. Therefore, we insist that any patent license obtained for a version of the library must be consistent with the full freedom of use specified in this license.</p>
-
-        <p>Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license, the GNU Lesser General Public License, applies to certain designated libraries, and is quite different from the ordinary General Public License. We use this license for certain libraries in order to permit linking those libraries into non-free programs.</p>
-
-        <p>When a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. The ordinary General Public License therefore permits such linking only if the entire combination fits its criteria of freedom. The Lesser General Public License permits more lax criteria for linking other code with the library.</p>
-
-        <p>We call this license the &quot;Lesser&quot; General Public License because it does Less to protect the user's freedom than the ordinary General Public License. It also provides other free software developers Less of an advantage over competing non-free programs. These disadvantages are the reason we use the ordinary General Public License for many libraries. However, the Lesser license provides advantages in certain special circumstances.</p>
-
-        <p>For example, on rare occasions, there may be a special need to encourage the widest possible use of a certain library, so that it becomes a de-facto standard. To achieve this, non-free programs must be allowed to use the library. A more frequent case is that a free library does the same job as widely used non-free libraries. In this case, there is little to gain by limiting the free library to free software only, so we use the Lesser General Public License.</p>
-
-        <p>In other cases, permission to use a particular library in non-free programs enables a greater number of people to use a large body of free software. For example, permission to use the GNU C Library in non-free programs enables many more people to use the whole GNU operating system, as well as its variant, the GNU/Linux operating system.</p>
-
-        <p>Although the Lesser General Public License is Less protective of the users' freedom, it does ensure that the user of a program that is linked with the Library has the freedom and the wherewithal to run that program using a modified version of the Library.</p>
-
-        <p>The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a &quot;work based on the library&quot; and a &quot;work that uses the library&quot;. The former contains code derived from the library, whereas the latter must be combined with the library in order to run.</p>
-
-        <p>TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION 0. This License Agreement applies to any software library or other program which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Lesser General Public License (also called &quot;this License&quot;). Each licensee is addressed as &quot;you&quot;.</p>
-
-        <p>A &quot;library&quot; means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.</p>
-
-        <p>The &quot;Library&quot;, below, refers to any such software library or work which has been distributed under these terms. A &quot;work based on the Library&quot; means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term &quot;modification&quot;.)</p>
-
-        <p>&quot;Source code&quot; for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.</p>
-
-        <p>Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.</p>
-
-        <p>1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.</p>
-
-        <p>You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.</p>
-
-        <p>2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:</p>
-
-        <p>a) The modified work must itself be a software library. b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change. c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License. d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful. (For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)</p>
-
-        <p>These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.</p>
-
-        <p>Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.</p>
-
-        <p>In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.</p>
-
-        <p>3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.</p>
-
-        <p>Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.</p>
-
-        <p>This option is useful when you wish to copy part of the code of the Library into a program that is not a library.</p>
-
-        <p>4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.</p>
-
-        <p>If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.</p>
-
-        <p>5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a &quot;work that uses the Library&quot;. Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.</p>
-
-        <p>However, linking a &quot;work that uses the Library&quot; with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a &quot;work that uses the library&quot;. The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.</p>
-
-        <p>When a &quot;work that uses the Library&quot; uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.</p>
-
-        <p>If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)</p>
-
-        <p>Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.</p>
-
-        <p>6. As an exception to the Sections above, you may also combine or link a &quot;work that uses the Library&quot; with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.</p>
-
-        <p>You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:</p>
-
-        <p>a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable &quot;work that uses the Library&quot;, as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.) b) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with. c) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution. d) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place. e) Verify that the user has already received a copy of these materials or that you have already sent this user a copy. For an executable, the required form of the &quot;work that uses the Library&quot; must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the materials to be distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.</p>
-
-        <p>It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.</p>
-
-        <p>7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:</p>
-
-        <p>a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above. b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work. 8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.</p>
-
-        <p>9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.</p>
-
-        <p>10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties with this License.</p>
-
-        <p>11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.</p>
-
-        <p>If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.</p>
-
-        <p>It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.</p>
-
-        <p>This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.</p>
-
-        <p>12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.</p>
-
-        <p>13. The Free Software Foundation may publish revised and/or new versions of the Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.</p>
-
-        <p>Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and &quot;any later version&quot;, you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.</p>
-
-        <p>14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.</p>
-
-        <p>NO WARRANTY</p>
-
-        <p>15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY &quot;AS IS&quot; WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.</p>
-
-        <p>16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
-
-        <p>END OF TERMS AND CONDITIONS How to Apply These Terms to Your New Libraries If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).</p>
-
-        <p>To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the &quot;copyright&quot; line and a pointer to where the full notice is found.</p>
-
-        <p>one line to give the library's name and an idea of what it does. Copyright (C) year name of author</p>
-
-        <p>This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.</p>
-
-        <p>This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.</p>
-
-        <p>You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA Also add information on how to contact you by electronic and paper mail.</p>
-
-        <p>You should also get your employer (if you work as a programmer) or your school, if any, to sign a &quot;copyright disclaimer&quot; for the library, if necessary. Here is a sample; alter the names:</p>
-
-        <p>Yoyodyne, Inc., hereby disclaims all copyright interest in the library &#96;Frob' (a library for tweaking knobs) written by James Random Hacker.</p>
-
-        <p>signature of Ty Coon, 1 April 1990 Ty Coon, President of Vice That's all there is to it!</p>
-
-
-        <!--        QT-->
-        <p><strong>QT</strong></p>
-        <p>GNU LESSER GENERAL PUBLIC LICENSE Version 3, 29 June 2007</p>
-
-        <p>Copyright (C) 2007 Free Software Foundation, Inc. Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.</p>
-
-        <p>This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.</p>
-
-        <p>0. Additional Definitions.</p>
-
-        <p>As used herein, &quot;this License&quot; refers to version 3 of the GNU Lesser General Public License, and the &quot;GNU GPL&quot; refers to version 3 of the GNU General Public License.</p>
-
-        <p>&quot;The Library&quot; refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.</p>
-
-        <p>An &quot;Application&quot; is any work that makes use of an interface provided by the Library, but which is not otherwise based on the Library. Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by the Library.</p>
-
-        <p>A &quot;Combined Work&quot; is a work produced by combining or linking an Application with the Library. The particular version of the Library with which the Combined Work was made is also called the &quot;Linked Version&quot;.</p>
-
-        <p>The &quot;Minimal Corresponding Source&quot; for a Combined Work means the Corresponding Source for the Combined Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not on the Linked Version.</p>
-
-        <p>The &quot;Corresponding Application Code&quot; for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.</p>
-
-        <p>1. Exception to Section 3 of the GNU GPL.</p>
-
-        <p>You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.</p>
-
-        <p>2. Conveying Modified Versions.</p>
-
-        <p>If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:</p>
-
-        <p>a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or</p>
-
-        <p>b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.</p>
-
-        <p>3. Object Code Incorporating Material from Library Header Files.</p>
-
-        <p>The object code form of an Application may incorporate material from a header file that is part of the Library. You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:</p>
-
-        <p>a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.</p>
-
-        <p>b) Accompany the object code with a copy of the GNU GPL and this license document.</p>
-
-        <p>4. Combined Works.</p>
-
-        <p>You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:</p>
-
-        <p>a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.</p>
-
-        <p>b) Accompany the Combined Work with a copy of the GNU GPL and this license document.</p>
-
-        <p>c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.</p>
-
-        <p>d) Do one of the following:</p>
-
-        <p>0) Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.</p>
-
-        <p>1) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (a) uses at run time a copy of the Library already present on the user's computer system, and (b) will operate properly with a modified version of the Library that is interface-compatible with the Linked Version.</p>
-
-        <p>e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)</p>
-
-        <p>5. Combined Libraries.</p>
-
-        <p>You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:</p>
-
-        <p>a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.</p>
-
-        <p>b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.</p>
-
-        <p>6. Revised Versions of the GNU Lesser General Public License.</p>
-
-        <p>The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.</p>
-
-        <p>Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License &quot;or any later version&quot; applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.</p>
-
-        <p>If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.</p>
-
-        <!--        Openssl-->
-        <p><strong>Openssl License</strong></p>
-
-        <p>/* ====================================================================<br />
-         * Copyright (c) 1998-2018 The OpenSSL Project. All rights reserved.<br />
-         *<br />
-         * Redistribution and use in source and binary forms, with or without<br />
-         * modification, are permitted provided that the following conditions<br />
-         * are met:<br />
-         *<br />
-         * 1. Redistributions of source code must retain the above copyright<br />
-         * notice, this list of conditions and the following disclaimer. <br />
-         *<br />
-         * 2. Redistributions in binary form must reproduce the above copyright<br />
-         * notice, this list of conditions and the following disclaimer in<br />
-         * the documentation and/or other materials provided with the<br />
-         * distribution.<br />
-         *<br />
-         * 3. All advertising materials mentioning features or use of this<br />
-         * software must display the following acknowledgment:<br />
-         * &quot;This product includes software developed by the OpenSSL Project<br />
-         * for use in the OpenSSL Toolkit. (http://www.openssl.org/)&quot;<br />
-         *<br />
-         * 4. The names &quot;OpenSSL Toolkit&quot; and &quot;OpenSSL Project&quot; must not be used to<br />
-         * endorse or promote products derived from this software without<br />
-         * prior written permission. For written permission, please contact<br />
-         * openssl-core@openssl.org.<br />
-         *<br />
-         * 5. Products derived from this software may not be called &quot;OpenSSL&quot;<br />
-         * nor may &quot;OpenSSL&quot; appear in their names without prior written<br />
-         * permission of the OpenSSL Project.<br />
-         *<br />
-         * 6. Redistributions of any form whatsoever must retain the following<br />
-         * acknowledgment:<br />
-         * &quot;This product includes software developed by the OpenSSL Project<br />
-         * for use in the OpenSSL Toolkit (http://www.openssl.org/)&quot;<br />
-         *<br />
-         * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT &#96;&#96;AS IS'' AND ANY<br />
-         * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE<br />
-         * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR<br />
-         * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE OpenSSL PROJECT OR<br />
-         * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,<br />
-         * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT<br />
-         * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;<br />
-         * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)<br />
-         * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,<br />
-         * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)<br />
-         * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED<br />
-         * OF THE POSSIBILITY OF SUCH DAMAGE.<br />
-         * ====================================================================<br />
-         *<br />
-         * This product includes cryptographic software written by Eric Young<br />
-         * (eay@cryptsoft.com). This product includes software written by Tim<br />
-         * Hudson (tjh@cryptsoft.com).<br />
-         *<br />
-         */</p>
-
-        <p><strong>Original SSLeay License</strong><br />
-         -----------------------</p>
-
-        <p>/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)<br />
-         * All rights reserved.<br />
-         *<br />
-         * This package is an SSL implementation written<br />
-         * by Eric Young (eay@cryptsoft.com).<br />
-         * The implementation was written so as to conform with Netscapes SSL.<br />
-         * <br />
-         * This library is free for commercial and non-commercial use as long as<br />
-         * the following conditions are aheared to. The following conditions<br />
-         * apply to all code found in this distribution, be it the RC4, RSA,<br />
-         * lhash, DES, etc., code; not just the SSL code. The SSL documentation<br />
-         * included with this distribution is covered by the same copyright terms<br />
-         * except that the holder is Tim Hudson (tjh@cryptsoft.com).<br />
-         * <br />
-         * Copyright remains Eric Young's, and as such any Copyright notices in<br />
-         * the code are not to be removed.<br />
-         * If this package is used in a product, Eric Young should be given attribution<br />
-         * as the author of the parts of the library used.<br />
-         * This can be in the form of a textual message at program startup or<br />
-         * in documentation (online or textual) provided with the package.<br />
-         * <br />
-         * Redistribution and use in source and binary forms, with or without<br />
-         * modification, are permitted provided that the following conditions<br />
-         * are met:<br />
-         * 1. Redistributions of source code must retain the copyright<br />
-         * notice, this list of conditions and the following disclaimer.<br />
-         * 2. Redistributions in binary form must reproduce the above copyright<br />
-         * notice, this list of conditions and the following disclaimer in the<br />
-         * documentation and/or other materials provided with the distribution.<br />
-         * 3. All advertising materials mentioning features or use of this software<br />
-         * must display the following acknowledgement:<br />
-         * &quot;This product includes cryptographic software written by<br />
-         * Eric Young (eay@cryptsoft.com)&quot;<br />
-         * The word 'cryptographic' can be left out if the rouines from the library<br />
-         * being used are not cryptographic related :-).<br />
-         * 4. If you include any Windows specific code (or a derivative thereof) from <br />
-         * the apps directory (application code) you must include an acknowledgement:<br />
-         * &quot;This product includes software written by Tim Hudson (tjh@cryptsoft.com)&quot;<br />
-         * <br />
-         * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG &#96;&#96;AS IS'' AND<br />
-         * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE<br />
-         * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE<br />
-         * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE<br />
-         * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL<br />
-         * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS<br />
-         * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)<br />
-         * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT<br />
-         * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY<br />
-         * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF<br />
-         * SUCH DAMAGE.<br />
-         * <br />
-         * The licence and distribution terms for any publically available version or<br />
-         * derivative of this code cannot be changed. i.e. this code cannot simply be<br />
-         * copied and put under another distribution licence<br />
-         * [including the GNU Public Licence.]<br />
-         */<br />
-        </p>
-        <p><strong>Additional 3rd party Software Credits:</strong><br/>
-            In addition to the 3rd party libraries enumerated above, Shotgun Desktop integrates various Shotgun Toolkit components that are integrating 3rd party libraries. The list of libraries of each component distributed with Shotgun Desktop can be found here:<br/>
-            <ul>
-            <li><a href="https://github.com/shotgunsoftware/tk-framework-desktopstartup/blob/master/python/server/software_credits">tk-framework-desktopstartup</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-core/blob/master/software_credits">tk-core</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-multi-pythonconsole/blob/master/software_credits">tk-multi-pythonconsole</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-nuke-quickreview/blob/master/software_credits">tk-nuke-quickreview</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-alias/blob/master/software_credits">tk-alias</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-multi-launchapp/blob/master/software_credits">tk-multi-launchapp</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-photoshopcc/blob/master/software_credits">tk-photoshopcc</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-framework-desktopserver/blob/master/software_credits">tk-framework-desktopserver</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-vred/blob/master/software_credits">tk-vred</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-framework-widget/blob/master/software_credits">tk-framework-widget</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-maya/blob/master/software_credits">tk-maya</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-houdini/blob/master/software_credits">tk-houdini</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-framework-adobe/blob/master/cep/software_credits">tk-framework-adobe</a></li>
-            <li><a href="https://github.com/shotgunsoftware/tk-multi-reviewsubmission/blob/master/software_credits">tk-multi-reviewsubmission</a></li>
-            <li><a href="https://github.com/shotgunsoftware/python-api/blob/master/software_credits">Shotgun Python API</a></li>
-            </ul>
-        </p>
-    </body>
+<body>
+<!--        Autodesk licence header-->
+<div>
+    <p><strong>Shotgun Desktop &copy; 2020 Autodesk, Inc. All rights reserved.</strong></p>
+    <p>
+        <strong>All use of this Software is subject to the Autodesk terms of service accepted upon access or use of this
+            Service or made available on the Autodesk webpage. Autodesk terms of service for Autodesk's various web
+            services can be found <a
+                    href="https://www.autodesk.com/company/legal-notices-trademarks/terms-of-service-autodesk360-web-services">here</a>.</strong>
+    </p>
+    <p>
+        <strong>Privacy</strong><br/>To learn more about Autodesk's online and offline privacy practices, please see the
+        <a href="http://www.autodesk.com/company/legal-notices-trademarks/privacy-statement">Autodesk Privacy
+            Statement</a>.
+    </p>
+    <p>
+        <strong>Autodesk Trademarks</strong><br/>The trademarks on the <a
+            href="http://www.autodesk.com/company/legal-notices-trademarks/trademarks/autodesk-inc">Autodesk Trademarks
+        page</a> are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in
+        the USA and/or other countries. &nbsp;&nbsp;All other brand names, product names or trademarks belong to their
+        respective holders.
+    </p>
+    <p>
+        <strong>Patents</strong><br/>This Service is protected by patents listed on the <a
+            href="https://www.autodesk.com/company/legal-notices-trademarks/patents">Autodesk Patents page</a>.
+    </p>
+    <p>
+        <strong>Autodesk Cloud and Desktop Components</strong><br/> This Service may incorporate or use background
+        Autodesk online and desktop technology components. For information about these components, see <a
+            href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cloud-platform-components">Autodesk
+        Cloud Platform Components</a> and <a
+            href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components">Autodesk
+        Desktop Platform Components</a>.
+    </p>
+    <p>
+        <strong>Third-Party Trademarks, Software Credits and Attributions</strong>
+    </p>
+</div>
+
+<!--        Python 2.7-->
+<div>
+    <p><strong>Python 2.7</strong></p>
+    <p>1. This LICENSE AGREEMENT is between the Python Software Foundation (&quot;PSF&quot;), and<br>
+        the Individual or Organization (&quot;Licensee&quot;) accessing and otherwise using Python<br>
+        2.7.17 software in source or binary form and its associated documentation.</p>
+
+    <p>2. Subject to the terms and conditions of this License Agreement, PSF hereby<br>
+        grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,<br>
+        analyze, test, perform and/or display publicly, prepare derivative works,<br>
+        distribute, and otherwise use Python 2.7.17 alone or in any derivative<br>
+        version, provided, however, that PSF's License Agreement and PSF's notice of<br>
+        copyright, i.e., &quot;Copyright &copy; 2001-2020 Python Software Foundation; All Rights<br>
+        Reserved&quot; are retained in Python 2.7.17 alone or in any derivative version<br>
+        prepared by Licensee.</p>
+
+    <p>3. In the event Licensee prepares a derivative work that is based on or<br>
+        incorporates Python 2.7.17 or any part thereof, and wants to make the<br>
+        derivative work available to others as provided herein, then Licensee hereby<br>
+        agrees to include in any such work a brief summary of the changes made to Python<br>
+        2.7.17.</p>
+
+    <p>4. PSF is making Python 2.7.17 available to Licensee on an &quot;AS IS&quot; basis.<br>
+        PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF<br>
+        EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR<br>
+        WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE<br>
+        USE OF PYTHON 2.7.17 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.</p>
+
+    <p>5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 2.7.17<br>
+        FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF<br>
+        MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 2.7.17, OR ANY DERIVATIVE<br>
+        THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.</p>
+
+    <p>6. This License Agreement will automatically terminate upon a material breach of<br>
+        its terms and conditions.</p>
+
+    <p>7. Nothing in this License Agreement shall be deemed to create any relationship<br>
+        of agency, partnership, or joint venture between PSF and Licensee. This License<br>
+        Agreement does not grant permission to use PSF trademarks or trade name in a<br>
+        trademark sense to endorse or promote products or services of Licensee, or any<br>
+        third party.</p>
+
+    <p>8. By copying, installing or otherwise using Python 2.7.17, Licensee agrees<br>
+        to be bound by the terms and conditions of this License Agreement.</p>
+</div>
+
+<!--        Python 3.7-->
+<div>
+    <p><strong>Python 3.7</strong></p>
+    <p>1. This LICENSE AGREEMENT is between the Python Software Foundation (&quot;PSF&quot;), and<br>
+        the Individual or Organization (&quot;Licensee&quot;) accessing and otherwise using Python<br>
+        3.7.6 software in source or binary form and its associated documentation.</p>
+
+    <p>2. Subject to the terms and conditions of this License Agreement, PSF hereby<br>
+        grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,<br>
+        analyze, test, perform and/or display publicly, prepare derivative works,<br>
+        distribute, and otherwise use Python 3.7.6 alone or in any derivative<br>
+        version, provided, however, that PSF's License Agreement and PSF's notice of<br>
+        copyright, i.e., &quot;Copyright &copy; 2001-2020 Python Software Foundation; All Rights<br>
+        Reserved&quot; are retained in Python 3.7.6 alone or in any derivative version<br>
+        prepared by Licensee.</p>
+
+    <p>3. In the event Licensee prepares a derivative work that is based on or<br>
+        incorporates Python 3.7.6 or any part thereof, and wants to make the<br>
+        derivative work available to others as provided herein, then Licensee hereby<br>
+        agrees to include in any such work a brief summary of the changes made to Python<br>
+        3.7.6.</p>
+
+    <p>4. PSF is making Python 3.7.6 available to Licensee on an &quot;AS IS&quot; basis.<br>
+        PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF<br>
+        EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR<br>
+        WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE<br>
+        USE OF PYTHON 3.7.6 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.</p>
+
+    <p>5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.7.6<br>
+        FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF<br>
+        MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.7.6, OR ANY DERIVATIVE<br>
+        THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.</p>
+
+    <p>6. This License Agreement will automatically terminate upon a material breach of<br>
+        its terms and conditions.</p>
+
+    <p>7. Nothing in this License Agreement shall be deemed to create any relationship<br>
+        of agency, partnership, or joint venture between PSF and Licensee. This License<br>
+        Agreement does not grant permission to use PSF trademarks or trade name in a<br>
+        trademark sense to endorse or promote products or services of Licensee, or any<br>
+        third party.</p>
+
+    <p>8. By copying, installing or otherwise using Python 3.7.6, Licensee agrees<br>
+        to be bound by the terms and conditions of this License Agreement.</p>
+</div>
+
+<!--        PySide2-->
+<div>
+    <p><strong>PySide2:</strong></p>
+    <p>PySide is licensed under the LGPL version 2.1 license, allowing both Free/Open source software and proprietary
+        software development.</p>
+
+    <p>GNU LESSER GENERAL PUBLIC LICENSE Version 2.1, February 1999</p>
+
+    <p>Copyright (C) 1991, 1999 Free Software Foundation, Inc. 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+        USA Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
+        not allowed.</p>
+
+    <p>[This is the first released version of the Lesser GPL. It also counts as the successor of the GNU Library Public
+        License, version 2, hence the version number 2.1.] Preamble The licenses for most software are designed to take
+        away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee
+        your freedom to share and change free software--to make sure the software is free for all its users.</p>
+
+    <p>This license, the Lesser General Public License, applies to some specially designated software
+        packages--typically libraries--of the Free Software Foundation and other authors who decide to use it. You can
+        use it too, but we suggest you first think carefully about whether this license or the ordinary General Public
+        License is the better strategy to use in any particular case, based on the explanations below.</p>
+
+    <p>When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are
+        designed to make sure that you have the freedom to distribute copies of free software (and charge for this
+        service if you wish); that you receive source code or can get it if you want it; that you can change the
+        software and use pieces of it in new free programs; and that you are informed that you can do these things.</p>
+
+    <p>To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask
+        you to surrender these rights. These restrictions translate to certain responsibilities for you if you
+        distribute copies of the library or if you modify it.</p>
+
+    <p>For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients
+        all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you
+        link other code with the library, you must provide complete object files to the recipients, so that they can
+        relink them with the library after making changes to the library and recompiling it. And you must show them
+        these terms so they know their rights.</p>
+
+    <p>We protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this license,
+        which gives you legal permission to copy, distribute and/or modify the library.</p>
+
+    <p>To protect each distributor, we want to make it very clear that there is no warranty for the free library. Also,
+        if the library is modified by someone else and passed on, the recipients should know that what they have is not
+        the original version, so that the original author's reputation will not be affected by problems that might be
+        introduced by others.</p>
+
+    <p>Finally, software patents pose a constant threat to the existence of any free program. We wish to make sure that
+        a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a
+        patent holder. Therefore, we insist that any patent license obtained for a version of the library must be
+        consistent with the full freedom of use specified in this license.</p>
+
+    <p>Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license,
+        the GNU Lesser General Public License, applies to certain designated libraries, and is quite different from the
+        ordinary General Public License. We use this license for certain libraries in order to permit linking those
+        libraries into non-free programs.</p>
+
+    <p>When a program is linked with a library, whether statically or using a shared library, the combination of the two
+        is legally speaking a combined work, a derivative of the original library. The ordinary General Public License
+        therefore permits such linking only if the entire combination fits its criteria of freedom. The Lesser General
+        Public License permits more lax criteria for linking other code with the library.</p>
+
+    <p>We call this license the &quot;Lesser&quot; General Public License because it does Less to protect the user's
+        freedom than the ordinary General Public License. It also provides other free software developers Less of an
+        advantage over competing non-free programs. These disadvantages are the reason we use the ordinary General
+        Public License for many libraries. However, the Lesser license provides advantages in certain special
+        circumstances.</p>
+
+    <p>For example, on rare occasions, there may be a special need to encourage the widest possible use of a certain
+        library, so that it becomes a de-facto standard. To achieve this, non-free programs must be allowed to use the
+        library. A more frequent case is that a free library does the same job as widely used non-free libraries. In
+        this case, there is little to gain by limiting the free library to free software only, so we use the Lesser
+        General Public License.</p>
+
+    <p>In other cases, permission to use a particular library in non-free programs enables a greater number of people to
+        use a large body of free software. For example, permission to use the GNU C Library in non-free programs enables
+        many more people to use the whole GNU operating system, as well as its variant, the GNU/Linux operating
+        system.</p>
+
+    <p>Although the Lesser General Public License is Less protective of the users' freedom, it does ensure that the user
+        of a program that is linked with the Library has the freedom and the wherewithal to run that program using a
+        modified version of the Library.</p>
+
+    <p>The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the
+        difference between a &quot;work based on the library&quot; and a &quot;work that uses the library&quot;. The
+        former contains code derived from the library, whereas the latter must be combined with the library in order to
+        run.</p>
+
+    <p>TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION 0. This License Agreement applies to any software
+        library or other program which contains a notice placed by the copyright holder or other authorized party saying
+        it may be distributed under the terms of this Lesser General Public License (also called &quot;this License&quot;).
+        Each licensee is addressed as &quot;you&quot;.</p>
+
+    <p>A &quot;library&quot; means a collection of software functions and/or data prepared so as to be conveniently
+        linked with application programs (which use some of those functions and data) to form executables.</p>
+
+    <p>The &quot;Library&quot;, below, refers to any such software library or work which has been distributed under
+        these terms. A &quot;work based on the Library&quot; means either the Library or any derivative work under
+        copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with
+        modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included
+        without limitation in the term &quot;modification&quot;.)</p>
+
+    <p>&quot;Source code&quot; for a work means the preferred form of the work for making modifications to it. For a
+        library, complete source code means all the source code for all modules it contains, plus any associated
+        interface definition files, plus the scripts used to control compilation and installation of the library.</p>
+
+    <p>Activities other than copying, distribution and modification are not covered by this License; they are outside
+        its scope. The act of running a program using the Library is not restricted, and output from such a program is
+        covered only if its contents constitute a work based on the Library (independent of the use of the Library in a
+        tool for writing it). Whether that is true depends on what the Library does and what the program that uses the
+        Library does.</p>
+
+    <p>1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any
+        medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice
+        and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any
+        warranty; and distribute a copy of this License along with the Library.</p>
+
+    <p>You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty
+        protection in exchange for a fee.</p>
+
+    <p>2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the
+        Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that
+        you also meet all of these conditions:</p>
+
+    <p>a) The modified work must itself be a software library. b) You must cause the files modified to carry prominent
+        notices stating that you changed the files and the date of any change. c) You must cause the whole of the work
+        to be licensed at no charge to all third parties under the terms of this License. d) If a facility in the
+        modified Library refers to a function or a table of data to be supplied by an application program that uses the
+        facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort
+        to ensure that, in the event an application does not supply such function or table, the facility still operates,
+        and performs whatever part of its purpose remains meaningful. (For example, a function in a library to compute
+        square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection
+        2d requires that any application-supplied function or table used by this function must be optional: if the
+        application does not supply it, the square root function must still compute square roots.)</p>
+
+    <p>These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived
+        from the Library, and can be reasonably considered independent and separate works in themselves, then this
+        License, and its terms, do not apply to those sections when you distribute them as separate works. But when you
+        distribute the same sections as part of a whole which is a work based on the Library, the distribution of the
+        whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole,
+        and thus to each and every part regardless of who wrote it.</p>
+
+    <p>Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by
+        you; rather, the intent is to exercise the right to control the distribution of derivative or collective works
+        based on the Library.</p>
+
+    <p>In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on
+        the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of
+        this License.</p>
+
+    <p>3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given
+        copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer
+        to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than
+        version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if
+        you wish.) Do not make any other change in these notices.</p>
+
+    <p>Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public
+        License applies to all subsequent copies and derivative works made from that copy.</p>
+
+    <p>This option is useful when you wish to copy part of the code of the Library into a program that is not a
+        library.</p>
+
+    <p>4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or
+        executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete
+        corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above
+        on a medium customarily used for software interchange.</p>
+
+    <p>If distribution of object code is made by offering access to copy from a designated place, then offering
+        equivalent access to copy the source code from the same place satisfies the requirement to distribute the source
+        code, even though third parties are not compelled to copy the source along with the object code.</p>
+
+    <p>5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library
+        by being compiled or linked with it, is called a &quot;work that uses the Library&quot;. Such a work, in
+        isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.</p>
+
+    <p>However, linking a &quot;work that uses the Library&quot; with the Library creates an executable that is a
+        derivative of the Library (because it contains portions of the Library), rather than a &quot;work that uses the
+        library&quot;. The executable is therefore covered by this License. Section 6 states terms for distribution of
+        such executables.</p>
+
+    <p>When a &quot;work that uses the Library&quot; uses material from a header file that is part of the Library, the
+        object code for the work may be a derivative work of the Library even though the source code is not. Whether
+        this is true is especially significant if the work can be linked without the Library, or if the work is itself a
+        library. The threshold for this to be true is not precisely defined by law.</p>
+
+    <p>If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and
+        small inline functions (ten lines or less in length), then the use of the object file is unrestricted,
+        regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of
+        the Library will still fall under Section 6.)</p>
+
+    <p>Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the
+        terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are
+        linked directly with the Library itself.</p>
+
+    <p>6. As an exception to the Sections above, you may also combine or link a &quot;work that uses the Library&quot;
+        with the Library to produce a work containing portions of the Library, and distribute that work under terms of
+        your choice, provided that the terms permit modification of the work for the customer's own use and reverse
+        engineering for debugging such modifications.</p>
+
+    <p>You must give prominent notice with each copy of the work that the Library is used in it and that the Library and
+        its use are covered by this License. You must supply a copy of this License. If the work during execution
+        displays copyright notices, you must include the copyright notice for the Library among them, as well as a
+        reference directing the user to the copy of this License. Also, you must do one of these things:</p>
+
+    <p>a) Accompany the work with the complete corresponding machine-readable source code for the Library including
+        whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the
+        work is an executable linked with the Library, with the complete machine-readable &quot;work that uses the
+        Library&quot;, as object code and/or source code, so that the user can modify the Library and then relink to
+        produce a modified executable containing the modified Library. (It is understood that the user who changes the
+        contents of definitions files in the Library will not necessarily be able to recompile the application to use
+        the modified definitions.) b) Use a suitable shared library mechanism for linking with the Library. A suitable
+        mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system,
+        rather than copying library functions into the executable, and (2) will operate properly with a modified version
+        of the library, if the user installs one, as long as the modified version is interface-compatible with the
+        version that the work was made with. c) Accompany the work with a written offer, valid for at least three years,
+        to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of
+        performing this distribution. d) If distribution of the work is made by offering access to copy from a
+        designated place, offer equivalent access to copy the above specified materials from the same place. e) Verify
+        that the user has already received a copy of these materials or that you have already sent this user a copy. For
+        an executable, the required form of the &quot;work that uses the Library&quot; must include any data and utility
+        programs needed for reproducing the executable from it. However, as a special exception, the materials to be
+        distributed need not include anything that is normally distributed (in either source or binary form) with the
+        major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that
+        component itself accompanies the executable.</p>
+
+    <p>It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do
+        not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library
+        together in an executable that you distribute.</p>
+
+    <p>7. You may place library facilities that are a work based on the Library side-by-side in a single library
+        together with other library facilities not covered by this License, and distribute such a combined library,
+        provided that the separate distribution of the work based on the Library and of the other library facilities is
+        otherwise permitted, and provided that you do these two things:</p>
+
+    <p>a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other
+        library facilities. This must be distributed under the terms of the Sections above. b) Give prominent notice
+        with the combined library of the fact that part of it is a work based on the Library, and explaining where to
+        find the accompanying uncombined form of the same work. 8. You may not copy, modify, sublicense, link with, or
+        distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify,
+        sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under
+        this License. However, parties who have received copies, or rights, from you under this License will not have
+        their licenses terminated so long as such parties remain in full compliance.</p>
+
+    <p>9. You are not required to accept this License, since you have not signed it. However, nothing else grants you
+        permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if
+        you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the
+        Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Library or works based on it.</p>
+
+    <p>10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically
+        receives a license from the original licensor to copy, distribute, link with or modify the Library subject to
+        these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the
+        rights granted herein. You are not responsible for enforcing compliance by third parties with this License.</p>
+
+    <p>11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not
+        limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that
+        contradict the conditions of this License, they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent
+        obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license
+        would not permit royalty-free redistribution of the Library by all those who receive copies directly or
+        indirectly through you, then the only way you could satisfy both it and this License would be to refrain
+        entirely from distribution of the Library.</p>
+
+    <p>If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of
+        the section is intended to apply, and the section as a whole is intended to apply in other circumstances.</p>
+
+    <p>It is not the purpose of this section to induce you to infringe any patents or other property right claims or to
+        contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free
+        software distribution system which is implemented by public license practices. Many people have made generous
+        contributions to the wide range of software distributed through that system in reliance on consistent
+        application of that system; it is up to the author/donor to decide if he or she is willing to distribute
+        software through any other system and a licensee cannot impose that choice.</p>
+
+    <p>This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this
+        License.</p>
+
+    <p>12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by
+        copyrighted interfaces, the original copyright holder who places the Library under this License may add an
+        explicit geographical distribution limitation excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in
+        the body of this License.</p>
+
+    <p>13. The Free Software Foundation may publish revised and/or new versions of the Lesser General Public License
+        from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail
+        to address new problems or concerns.</p>
+
+    <p>Each version is given a distinguishing version number. If the Library specifies a version number of this License
+        which applies to it and &quot;any later version&quot;, you have the option of following the terms and conditions
+        either of that version or of any later version published by the Free Software Foundation. If the Library does
+        not specify a license version number, you may choose any version ever published by the Free Software
+        Foundation.</p>
+
+    <p>14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are
+        incompatible with these, write to the author to ask for permission. For software which is copyrighted by the
+        Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our
+        decision will be guided by the two goals of preserving the free status of all derivatives of our free software
+        and of promoting the sharing and reuse of software generally.</p>
+
+    <p>NO WARRANTY</p>
+
+    <p>15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED
+        BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE
+        THE LIBRARY &quot;AS IS&quot; WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT
+        LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS
+        TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE
+        COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.</p>
+
+    <p>16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER
+        PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING
+        ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+        PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS
+        BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
+
+    <p>END OF TERMS AND CONDITIONS How to Apply These Terms to Your New Libraries If you develop a new library, and you
+        want it to be of the greatest possible use to the public, we recommend making it free software that everyone can
+        redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under
+        the terms of the ordinary General Public License).</p>
+
+    <p>To apply these terms, attach the following notices to the library. It is safest to attach them to the start of
+        each source file to most effectively convey the exclusion of warranty; and each file should have at least the
+        &quot;copyright&quot; line and a pointer to where the full notice is found.</p>
+
+    <p>one line to give the library's name and an idea of what it does. Copyright (C) year name of author</p>
+
+    <p>This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
+        Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your
+        option) any later version.</p>
+
+    <p>This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+        implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+        License for more details.</p>
+
+    <p>You should have received a copy of the GNU Lesser General Public License along with this library; if not, write
+        to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA Also add
+        information on how to contact you by electronic and paper mail.</p>
+
+    <p>You should also get your employer (if you work as a programmer) or your school, if any, to sign a &quot;copyright
+        disclaimer&quot; for the library, if necessary. Here is a sample; alter the names:</p>
+
+    <p>Yoyodyne, Inc., hereby disclaims all copyright interest in the library &#96;Frob' (a library for tweaking knobs)
+        written by James Random Hacker.</p>
+
+    <p>signature of Ty Coon, 1 April 1990 Ty Coon, President of Vice That's all there is to it!</p>
+</div>
+
+<!--        QT-->
+<div>
+    <p><strong>QT</strong></p>
+    <p>GNU LESSER GENERAL PUBLIC LICENSE Version 3, 29 June 2007</p>
+
+    <p>Copyright (C) 2007 Free Software Foundation, Inc. Everyone is permitted to copy and distribute verbatim copies of
+        this license document, but changing it is not allowed.</p>
+
+    <p>This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the
+        GNU General Public License, supplemented by the additional permissions listed below.</p>
+
+    <p>0. Additional Definitions.</p>
+
+    <p>As used herein, &quot;this License&quot; refers to version 3 of the GNU Lesser General Public License, and the
+        &quot;GNU GPL&quot; refers to version 3 of the GNU General Public License.</p>
+
+    <p>&quot;The Library&quot; refers to a covered work governed by this License, other than an Application or a
+        Combined Work as defined below.</p>
+
+    <p>An &quot;Application&quot; is any work that makes use of an interface provided by the Library, but which is not
+        otherwise based on the Library. Defining a subclass of a class defined by the Library is deemed a mode of using
+        an interface provided by the Library.</p>
+
+    <p>A &quot;Combined Work&quot; is a work produced by combining or linking an Application with the Library. The
+        particular version of the Library with which the Combined Work was made is also called the &quot;Linked Version&quot;.</p>
+
+    <p>The &quot;Minimal Corresponding Source&quot; for a Combined Work means the Corresponding Source for the Combined
+        Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on
+        the Application, and not on the Linked Version.</p>
+
+    <p>The &quot;Corresponding Application Code&quot; for a Combined Work means the object code and/or source code for
+        the Application, including any data and utility programs needed for reproducing the Combined Work from the
+        Application, but excluding the System Libraries of the Combined Work.</p>
+
+    <p>1. Exception to Section 3 of the GNU GPL.</p>
+
+    <p>You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU
+        GPL.</p>
+
+    <p>2. Conveying Modified Versions.</p>
+
+    <p>If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be
+        supplied by an Application that uses the facility (other than as an argument passed when the facility is
+        invoked), then you may convey a copy of the modified version:</p>
+
+    <p>a) under this License, provided that you make a good faith effort to ensure that, in the event an Application
+        does not supply the function or data, the facility still operates, and performs whatever part of its purpose
+        remains meaningful, or</p>
+
+    <p>b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.</p>
+
+    <p>3. Object Code Incorporating Material from Library Header Files.</p>
+
+    <p>The object code form of an Application may incorporate material from a header file that is part of the Library.
+        You may convey such object code under terms of your choice, provided that, if the incorporated material is not
+        limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and
+        templates (ten or fewer lines in length), you do both of the following:</p>
+
+    <p>a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library
+        and its use are covered by this License.</p>
+
+    <p>b) Accompany the object code with a copy of the GNU GPL and this license document.</p>
+
+    <p>4. Combined Works.</p>
+
+    <p>You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict
+        modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging
+        such modifications, if you also do each of the following:</p>
+
+    <p>a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library
+        and its use are covered by this License.</p>
+
+    <p>b) Accompany the Combined Work with a copy of the GNU GPL and this license document.</p>
+
+    <p>c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the
+        Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this
+        license document.</p>
+
+    <p>d) Do one of the following:</p>
+
+    <p>0) Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application
+        Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a
+        modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6
+        of the GNU GPL for conveying Corresponding Source.</p>
+
+    <p>1) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (a)
+        uses at run time a copy of the Library already present on the user's computer system, and (b) will operate
+        properly with a modified version of the Library that is interface-compatible with the Linked Version.</p>
+
+    <p>e) Provide Installation Information, but only if you would otherwise be required to provide such information
+        under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute
+        a modified version of the Combined Work produced by recombining or relinking the Application with a modified
+        version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal
+        Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the
+        Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding
+        Source.)</p>
+
+    <p>5. Combined Libraries.</p>
+
+    <p>You may place library facilities that are a work based on the Library side by side in a single library together
+        with other library facilities that are not Applications and are not covered by this License, and convey such a
+        combined library under terms of your choice, if you do both of the following:</p>
+
+    <p>a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other
+        library facilities, conveyed under the terms of this License.</p>
+
+    <p>b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining
+        where to find the accompanying uncombined form of the same work.</p>
+
+    <p>6. Revised Versions of the GNU Lesser General Public License.</p>
+
+    <p>The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License
+        from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail
+        to address new problems or concerns.</p>
+
+    <p>Each version is given a distinguishing version number. If the Library as you received it specifies that a certain
+        numbered version of the GNU Lesser General Public License &quot;or any later version&quot; applies to it, you
+        have the option of following the terms and conditions either of that published version or of any later version
+        published by the Free Software Foundation. If the Library as you received it does not specify a version number
+        of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License
+        ever published by the Free Software Foundation.</p>
+
+    <p>If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser
+        General Public License shall apply, that proxy's public statement of acceptance of any version is permanent
+        authorization for you to choose that version for the Library.</p>
+</div>
+
+<!--        Openssl-->
+<div>
+    <p><strong>Openssl License</strong></p>
+
+    <p>/* ====================================================================<br/>
+        * Copyright (c) 1998-2018 The OpenSSL Project. All rights reserved.<br/>
+        *<br/>
+        * Redistribution and use in source and binary forms, with or without<br/>
+        * modification, are permitted provided that the following conditions<br/>
+        * are met:<br/>
+        *<br/>
+        * 1. Redistributions of source code must retain the above copyright<br/>
+        * notice, this list of conditions and the following disclaimer. <br/>
+        *<br/>
+        * 2. Redistributions in binary form must reproduce the above copyright<br/>
+        * notice, this list of conditions and the following disclaimer in<br/>
+        * the documentation and/or other materials provided with the<br/>
+        * distribution.<br/>
+        *<br/>
+        * 3. All advertising materials mentioning features or use of this<br/>
+        * software must display the following acknowledgment:<br/>
+        * &quot;This product includes software developed by the OpenSSL Project<br/>
+        * for use in the OpenSSL Toolkit. (http://www.openssl.org/)&quot;<br/>
+        *<br/>
+        * 4. The names &quot;OpenSSL Toolkit&quot; and &quot;OpenSSL Project&quot; must not be used to<br/>
+        * endorse or promote products derived from this software without<br/>
+        * prior written permission. For written permission, please contact<br/>
+        * openssl-core@openssl.org.<br/>
+        *<br/>
+        * 5. Products derived from this software may not be called &quot;OpenSSL&quot;<br/>
+        * nor may &quot;OpenSSL&quot; appear in their names without prior written<br/>
+        * permission of the OpenSSL Project.<br/>
+        *<br/>
+        * 6. Redistributions of any form whatsoever must retain the following<br/>
+        * acknowledgment:<br/>
+        * &quot;This product includes software developed by the OpenSSL Project<br/>
+        * for use in the OpenSSL Toolkit (http://www.openssl.org/)&quot;<br/>
+        *<br/>
+        * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT &#96;&#96;AS IS'' AND ANY<br/>
+        * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE<br/>
+        * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR<br/>
+        * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE OpenSSL PROJECT OR<br/>
+        * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,<br/>
+        * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT<br/>
+        * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;<br/>
+        * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)<br/>
+        * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,<br/>
+        * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)<br/>
+        * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED<br/>
+        * OF THE POSSIBILITY OF SUCH DAMAGE.<br/>
+        * ====================================================================<br/>
+        *<br/>
+        * This product includes cryptographic software written by Eric Young<br/>
+        * (eay@cryptsoft.com). This product includes software written by Tim<br/>
+        * Hudson (tjh@cryptsoft.com).<br/>
+        *<br/>
+        */</p>
+
+    <p><strong>Original SSLeay License</strong><br/>
+        -----------------------</p>
+
+    <p>/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)<br/>
+        * All rights reserved.<br/>
+        *<br/>
+        * This package is an SSL implementation written<br/>
+        * by Eric Young (eay@cryptsoft.com).<br/>
+        * The implementation was written so as to conform with Netscapes SSL.<br/>
+        * <br/>
+        * This library is free for commercial and non-commercial use as long as<br/>
+        * the following conditions are aheared to. The following conditions<br/>
+        * apply to all code found in this distribution, be it the RC4, RSA,<br/>
+        * lhash, DES, etc., code; not just the SSL code. The SSL documentation<br/>
+        * included with this distribution is covered by the same copyright terms<br/>
+        * except that the holder is Tim Hudson (tjh@cryptsoft.com).<br/>
+        * <br/>
+        * Copyright remains Eric Young's, and as such any Copyright notices in<br/>
+        * the code are not to be removed.<br/>
+        * If this package is used in a product, Eric Young should be given attribution<br/>
+        * as the author of the parts of the library used.<br/>
+        * This can be in the form of a textual message at program startup or<br/>
+        * in documentation (online or textual) provided with the package.<br/>
+        * <br/>
+        * Redistribution and use in source and binary forms, with or without<br/>
+        * modification, are permitted provided that the following conditions<br/>
+        * are met:<br/>
+        * 1. Redistributions of source code must retain the copyright<br/>
+        * notice, this list of conditions and the following disclaimer.<br/>
+        * 2. Redistributions in binary form must reproduce the above copyright<br/>
+        * notice, this list of conditions and the following disclaimer in the<br/>
+        * documentation and/or other materials provided with the distribution.<br/>
+        * 3. All advertising materials mentioning features or use of this software<br/>
+        * must display the following acknowledgement:<br/>
+        * &quot;This product includes cryptographic software written by<br/>
+        * Eric Young (eay@cryptsoft.com)&quot;<br/>
+        * The word 'cryptographic' can be left out if the rouines from the library<br/>
+        * being used are not cryptographic related :-).<br/>
+        * 4. If you include any Windows specific code (or a derivative thereof) from <br/>
+        * the apps directory (application code) you must include an acknowledgement:<br/>
+        * &quot;This product includes software written by Tim Hudson (tjh@cryptsoft.com)&quot;<br/>
+        * <br/>
+        * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG &#96;&#96;AS IS'' AND<br/>
+        * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE<br/>
+        * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE<br/>
+        * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE<br/>
+        * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL<br/>
+        * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS<br/>
+        * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)<br/>
+        * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT<br/>
+        * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY<br/>
+        * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF<br/>
+        * SUCH DAMAGE.<br/>
+        * <br/>
+        * The licence and distribution terms for any publically available version or<br/>
+        * derivative of this code cannot be changed. i.e. this code cannot simply be<br/>
+        * copied and put under another distribution licence<br/>
+        * [including the GNU Public Licence.]<br/>
+        */<br/>
+    </p>
+</div>
+
+<!--        PyObjC-->
+<div>
+    <p><strong>PyObjC</strong></p>
+    <p>(This is the MIT license, note that libffi-src is a separate product with its own license)</p>
+
+    §
+
+    <p> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+        documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+        the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+        to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+
+    <p> The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+        the Software.</p>
+
+    <p> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+        THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+        CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+        DEALINGS IN THE SOFTWARE.<br/>
+    </p>
+</div>
+
+<!--        six-->
+<div>
+    <p><strong>six</strong></p>
+
+    <p>Copyright (c) 2010-2020 Benjamin Peterson</p>
+
+    <p>Permission is hereby granted, free of charge, to any person obtaining a copy of<br/>
+        this software and associated documentation files (the "Software"), to deal in<br/>
+        the Software without restriction, including without limitation the rights to<br/>
+        use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of<br/>
+        the Software, and to permit persons to whom the Software is furnished to do so,<br/>
+        subject to the following conditions:</p>
+
+    <p>The above copyright notice and this permission notice shall be included in all<br/>
+        copies or substantial portions of the Software.</p>
+
+    <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR<br/>
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS<br/>
+        FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR<br/>
+        COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER<br/>
+        IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN<br/>
+        CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+</div>
+
+<!--       certifi-->
+<div>
+    <p><strong>certifi</strong></p>
+    <p>This Source Code Form is subject to the terms of the Mozilla Public License,
+        v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
+        one at http://mozilla.org/MPL/2.0/.</p>
+</div>
+
+<!--        cffi-->
+<div>
+    <p><strong>cffi</strong></p>
+
+    <p>Copyright (C) 2005-2006, James Bielman<br/>
+        Copyright (C) 2005-2010, Luis Oliveira </p>
+    <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+        documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+        the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+        to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+
+    <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+        the Software.</p>
+
+    <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+        THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+        CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+        DEALINGS IN THE SOFTWARE.</p>
+</div>
+
+<!--        ipaddress-->
+<div>
+    <p><strong>ipaddress</strong></p>
+    <p>This package is a modified version of cpython's ipaddress module.<br/>
+        It is therefore distributed under the PSF license, as follows:</p>
+
+    <p>PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2<br/>
+        --------------------------------------------</p>
+
+    <p>1. This LICENSE AGREEMENT is between the Python Software Foundation<br/>
+        ("PSF"), and the Individual or Organization ("Licensee") accessing and<br/>
+        otherwise using this software ("Python") in source or binary form and<br/>
+        its associated documentation.</p>
+
+    <p>2. Subject to the terms and conditions of this License Agreement, PSF hereby<br/>
+        grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,<br/>
+        analyze, test, perform and/or display publicly, prepare derivative works,<br/>
+        distribute, and otherwise use Python alone or in any derivative version,<br/>
+        provided, however, that PSF's License Agreement and PSF's notice of copyright,<br/>
+        i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,<br/>
+        2011, 2012, 2013, 2014 Python Software Foundation; All Rights Reserved" are<br/>
+        retained in Python alone or in any derivative version prepared by Licensee.</p>
+
+    <p>3. In the event Licensee prepares a derivative work that is based on<br/>
+        or incorporates Python or any part thereof, and wants to make<br/>
+        the derivative work available to others as provided herein, then<br/>
+        Licensee hereby agrees to include in any such work a brief summary of<br/>
+        the changes made to Python.</p>
+
+    <p>4. PSF is making Python available to Licensee on an "AS IS"<br/>
+        basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR<br/>
+        IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND<br/>
+        DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS<br/>
+        FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT<br/>
+        INFRINGE ANY THIRD PARTY RIGHTS.</p>
+
+    <p>5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON<br/>
+        FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS<br/>
+        A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,<br/>
+        OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.</p>
+
+    <p>6. This License Agreement will automatically terminate upon a material<br/>
+        breach of its terms and conditions.</p>
+
+    <p>7. Nothing in this License Agreement shall be deemed to create any<br/>
+        relationship of agency, partnership, or joint venture between PSF and<br/>
+        Licensee. This License Agreement does not grant permission to use PSF<br/>
+        trademarks or trade name in a trademark sense to endorse or promote<br/>
+        products or services of Licensee, or any third party.</p>
+
+    <p>8. By copying, installing or otherwise using Python, Licensee<br/>
+        agrees to be bound by the terms and conditions of this License<br/>
+        Agreement.</p>
+</div>
+
+<!--        pycparser-->
+<div>
+    <p><strong>pycparser</strong></p>
+    <p>pycparser -- A C parser in Python</p>
+
+    <p>Copyright (c) 2008-2020, Eli Bendersky<br/>
+        All rights reserved.</p>
+
+    <p>Redistribution and use in source and binary forms, with or without modification,<br/>
+        are permitted provided that the following conditions are met:</p>
+
+    <p>* Redistributions of source code must retain the above copyright notice, this <br/>
+        list of conditions and the following disclaimer.<br/>
+        * Redistributions in binary form must reproduce the above copyright notice, <br/>
+        this list of conditions and the following disclaimer in the documentation <br/>
+        and/or other materials provided with the distribution.<br/>
+        * Neither the name of Eli Bendersky nor the names of its contributors may <br/>
+        be used to endorse or promote products derived from this software without <br/>
+        specific prior written permission.</p>
+
+    <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND <br/>
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED <br/>
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE <br/>
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE <br/>
+        LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR <br/>
+        CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE <br/>
+        GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) <br/>
+        HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT <br/>
+        LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT <br/>
+        OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+</div>
+
+<!--        pip-->
+<div>
+    <p><strong>pip</strong></p>
+    <p>Copyright (c) 2008-2019 The pip developers (see AUTHORS.txt file)</p>
+
+    <p>Permission is hereby granted, free of charge, to any person obtaining<br/>
+        a copy of this software and associated documentation files (the<br/>
+        "Software"), to deal in the Software without restriction, including<br/>
+        without limitation the rights to use, copy, modify, merge, publish,<br/>
+        distribute, sublicense, and/or sell copies of the Software, and to<br/>
+        permit persons to whom the Software is furnished to do so, subject to<br/>
+        the following conditions:</p>
+
+    <p>The above copyright notice and this permission notice shall be<br/>
+        included in all copies or substantial portions of the Software.</p>
+
+    <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,<br/>
+        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF<br/>
+        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND<br/>
+        NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE<br/>
+        LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION<br/>
+        OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION<br/>
+        WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+</div>
+
+<!--        setuptools-->
+<div>
+    <p><strong>setuptools</strong></p>
+    <p>Copyright (C) 2016 Jason R Coombs
+        &lt;jaraco @jaraco.com&gt;
+    </p>
+
+    <p>Permission is hereby granted, free of charge, to any person obtaining a copy of<br/>
+        this software and associated documentation files (the "Software"), to deal in<br/>
+        the Software without restriction, including without limitation the rights to<br/>
+        use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies<br/>
+        of the Software, and to permit persons to whom the Software is furnished to do<br/>
+        so, subject to the following conditions:</p>
+
+    <p>The above copyright notice and this permission notice shall be included in all<br/>
+        copies or substantial portions of the Software.</p>
+
+    <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR<br/>
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,<br/>
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE<br/>
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER<br/>
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,<br/>
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE<br/>
+        SOFTWARE.</p>
+</div>
+
+<p><strong>Additional 3rd party Software Credits:</strong><br/>
+    In addition to the 3rd party libraries enumerated above, Shotgun Desktop integrates various Shotgun Toolkit
+    components that are integrating 3rd party libraries. The list of libraries of each component distributed with
+    Shotgun Desktop can be found here:<br/>
+<ul>
+    <li>
+        <a href="https://github.com/shotgunsoftware/tk-framework-desktopstartup/blob/master/python/server/software_credits">tk-framework-desktopstartup</a>
+    </li>
+    <li><a href="https://github.com/shotgunsoftware/tk-core/blob/master/software_credits">tk-core</a></li>
+    <li><a href="https://github.com/shotgunsoftware/tk-multi-pythonconsole/blob/master/software_credits">tk-multi-pythonconsole</a>
+    </li>
+    <li><a href="https://github.com/shotgunsoftware/tk-nuke-quickreview/blob/master/software_credits">tk-nuke-quickreview</a>
+    </li>
+    <li><a href="https://github.com/shotgunsoftware/tk-framework-desktopserver/blob/master/software_credits">tk-framework-desktopserver</a>
+    </li>
+    <li><a href="https://github.com/shotgunsoftware/tk-vred/blob/master/software_credits">tk-vred</a></li>
+    </li>
+    <li><a href="https://github.com/shotgunsoftware/tk-houdini/blob/master/software_credits">tk-houdini</a></li>
+    <li><a href="https://github.com/shotgunsoftware/tk-framework-adobe/blob/master/cep/software_credits">tk-framework-adobe</a>
+    </li>
+    <li><a href="https://github.com/shotgunsoftware/tk-multi-reviewsubmission/blob/master/software_credits">tk-multi-reviewsubmission</a>
+    </li>
+    <li><a href="https://github.com/shotgunsoftware/python-api/blob/master/software_credits">Shotgun Python API</a></li>
+</ul>
+</p>
+</body>
 </html>

--- a/python/tk_desktop/licenses.html
+++ b/python/tk_desktop/licenses.html
@@ -1145,6 +1145,9 @@
     <li>
         <a href="https://github.com/shotgunsoftware/tk-framework-desktopstartup/blob/master/python/server/software_credits">tk-framework-desktopstartup</a>
     </li>
+    <li>
+        <a href="https://github.com/shotgunsoftware/tk-framework-desktopclient/blob/master/software_credits">tk-framework-desktopclient</a>
+    </li>
     <li><a href="https://github.com/shotgunsoftware/tk-core/blob/master/software_credits">tk-core</a></li>
     <li><a href="https://github.com/shotgunsoftware/tk-multi-pythonconsole/blob/master/software_credits">tk-multi-pythonconsole</a>
     </li>
@@ -1152,10 +1155,10 @@
     </li>
     <li><a href="https://github.com/shotgunsoftware/tk-framework-desktopserver/blob/master/software_credits">tk-framework-desktopserver</a>
     </li>
-    <li><a href="https://github.com/shotgunsoftware/tk-vred/blob/master/software_credits">tk-vred</a></li>
-    </li>
     <li><a href="https://github.com/shotgunsoftware/tk-houdini/blob/master/software_credits">tk-houdini</a></li>
-    <li><a href="https://github.com/shotgunsoftware/tk-framework-adobe/blob/master/cep/software_credits">tk-framework-adobe</a>
+    <li><a href="https://github.com/shotgunsoftware/tk-3dsmax/blob/master/software_credits">tk-3dsmax</a></li>
+    <li><a href="https://github.com/shotgunsoftware/tk-3dsmaxplus/blob/master/software_credits">tk-3dsmaxplus</a></li>
+    <li><a href="https://github.com/shotgunsoftware/tk-framework-adobe/blob/master/software_credits">tk-framework-adobe</a>
     </li>
     <li><a href="https://github.com/shotgunsoftware/tk-multi-reviewsubmission/blob/master/software_credits">tk-multi-reviewsubmission</a>
     </li>

--- a/python/tk_desktop/licenses.html
+++ b/python/tk_desktop/licenses.html
@@ -1162,6 +1162,8 @@
     </li>
     <li><a href="https://github.com/shotgunsoftware/tk-multi-reviewsubmission/blob/master/software_credits">tk-multi-reviewsubmission</a>
     </li>
+    <li><a href="https://github.com/shotgunsoftware/tk-framework-lmv/blob/master/software_credits">tk-framework-lmv</a>
+    </li>
     <li><a href="https://github.com/shotgunsoftware/python-api/blob/master/software_credits">Shotgun Python API</a></li>
 </ul>
 </p>

--- a/python/tk_desktop/licenses.html
+++ b/python/tk_desktop/licenses.html
@@ -842,9 +842,10 @@
 <!--       certifi-->
 <div>
     <p><strong>certifi</strong></p>
-    <p>This Source Code Form is subject to the terms of the Mozilla Public License,
-        v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
-        one at http://mozilla.org/MPL/2.0/.</p>
+    <p>Certifi is licensed under the Mozilla Public License v.2.0,
+        which can be found at http://www.mozilla.org/MPL/2.0/.
+        A text copy of this license and the source code for Certifi 2020.06.20 (and modifications made by Autodesk, if any)
+        can be found at the Autodesk website www.autodesk.com/lgplsource.</p>
 </div>
 
 <!--        cffi-->

--- a/python/tk_desktop/licenses.html
+++ b/python/tk_desktop/licenses.html
@@ -1006,6 +1006,137 @@
         SOFTWARE.</p>
 </div>
 
+<!--        OpenSans-->
+<div>
+    <p><strong>OpenSans</strong></p>
+    <p>Apache License, Version 2.0<br/>
+        Apache License</p>
+
+    <p>Version 2.0, January 2004</p>
+
+    <p>http://www.apache.org/licenses/</p>
+
+    <p>TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION</p>
+
+    <p>1. Definitions.</p>
+
+    <p>"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1
+        through 9 of this document.</p>
+
+    <p>"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the
+        License.</p>
+
+    <p>"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by,
+        or are under common control with that entity. For the purposes of this definition, "control" means (i) the
+        power, direct or indirect, to cause the direction or management of such entity, whether by contract or
+        otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+        ownership of such entity.</p>
+
+    <p>"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.</p>
+
+    <p>"Source" form shall mean the preferred form for making modifications, including but not limited to software
+        source code, documentation source, and configuration files.</p>
+
+    <p>"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form,
+        including but not limited to compiled object code, generated documentation, and conversions to other media
+        types.</p>
+
+    <p>"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as
+        indicated by a copyright notice that is included in or attached to the work (an example is provided in the
+        Appendix below).</p>
+
+    <p>"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the
+        Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a
+        whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include
+        works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative
+        Works thereof.</p>
+
+    <p>"Contribution" shall mean any work of authorship, including the original version of the Work and any
+        modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor
+        for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on
+        behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic,
+        verbal, or written communication sent to the Licensor or its representatives, including but not limited to
+        communication on electronic mailing lists, source code control systems, and issue tracking systems that are
+        managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding
+        communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a
+        Contribution."</p>
+
+    <p>"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been
+        received by Licensor and subsequently incorporated within the Work.</p>
+
+    <p>2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby
+        grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+        reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work
+        and such Derivative Works in Source or Object form.</p>
+
+    <p>3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants
+        to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+        section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work,
+        where such license applies only to those patent claims licensable by such Contributor that are necessarily
+        infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such
+        Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or
+        counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes
+        direct or contributory patent infringement, then any patent licenses granted to You under this License for that
+        Work shall terminate as of the date such litigation is filed.</p>
+
+    <p>4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium,
+        with or without modifications, and in Source or Object form, provided that You meet the following
+        conditions:</p>
+
+    <p>You must give any other recipients of the Work or Derivative Works a copy of this License; and<br/>
+        You must cause any modified files to carry prominent notices stating that You changed the files; and<br/>
+        You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent,
+        trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain
+        to any part of the Derivative Works; and<br/>
+        If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You
+        distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding
+        those notices that do not pertain to any part of the Derivative Works, in at least one of the following places:
+        within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation,
+        if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and
+        wherever such third-party notices normally appear. The contents of the NOTICE file are for informational
+        purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works
+        that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional
+        attribution notices cannot be construed as modifying the License.</p>
+
+    <p>You may add Your own copyright statement to Your modifications and may provide additional or different license
+        terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative
+        Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the
+        conditions stated in this License.<br/>
+        5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted
+        for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License,
+        without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify
+        the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+    </p>
+
+    <p>6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or
+        product names of the Licensor, except as required for reasonable and customary use in describing the origin of
+        the Work and reproducing the content of the NOTICE file.</p>
+
+    <p>7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work
+        (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+        KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE,
+        NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for
+        determining the appropriateness of using or redistributing the Work and assume any risks associated with Your
+        exercise of permissions under this License.</p>
+
+    <p>8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence),
+        contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or
+        agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect,
+        special, incidental, or consequential damages of any character arising as a result of this License or out of the
+        use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage,
+        computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor
+        has been advised of the possibility of such damages.</p>
+
+    <p>9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may
+        choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability
+        obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only
+        on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You
+        agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted
+        against, such Contributor by reason of your accepting any such warranty or additional liability.</p>
+
+    <p>END OF TERMS AND CONDITIONS</p>
+</div>
+
 <p><strong>Additional 3rd party Software Credits:</strong><br/>
     In addition to the 3rd party libraries enumerated above, Shotgun Desktop integrates various Shotgun Toolkit
     components that are integrating 3rd party libraries. The list of libraries of each component distributed with

--- a/software_credits
+++ b/software_credits
@@ -1,0 +1,58 @@
+The Shotgun Desktop Engine uses the following software. Thanks to their creators, license information below.
+
+============================== OpenSans Fonts ==============================
+
+Apache License, Version 2.0
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS


### PR DESCRIPTION
This updates the about box licensing to include additional Python 3rd party licenses that we are bundling.
Also updates the component links to point to new software credit files and removes those that don't exist anymore.

I've also added div tags to the licence html to make it easier to collapse the licence sections in an editor.