### PR TITLE
SS-18239: undocked by default

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -11,6 +11,7 @@
 import sys
 
 import sgtk
+import traceback
 from sgtk.platform import Engine
 
 
@@ -79,6 +80,21 @@ class DesktopEngine(Engine):
                 interface_type = "project"
 
         self._is_site_engine = interface_type == "site"
+
+        previous_except_hook = sys.excepthook
+
+        def unhandled_exception_handler(exc_type, exc_value, exc_traceback):
+            engine = sgtk.platform.current_engine()
+            if engine:
+                self.logger.error(
+                    "".join(
+                        traceback.format_exception(exc_type, exc_value, exc_traceback)
+                    )
+                )
+            if previous_except_hook:
+                previous_except_hook(exc_type, exc_value, exc_traceback)
+
+        sys.excepthook = unhandled_exception_handler
 
         # Import our python library
         #

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -472,7 +472,7 @@ class DesktopWindow(SystrayWindow):
         # settings that apply across any instance (after site specific, so pinned can reset pos)
         self.set_on_top(self._settings_manager.retrieve("on_top", False))
 
-        # always start pinned and hidden
+        # always start unpinned and shown
         self.state = self._settings_manager.retrieve(
             "dialog_pinned", self.STATE_WINDOWED
         )

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -169,7 +169,6 @@ class DesktopWindow(SystrayWindow):
         self.__activation_hotkey = None
         self._settings_manager = settings.UserSettings(sgtk.platform.current_bundle())
 
-        self._has_warned_of_minimized_behaviour = False
         self._app_icon = QtGui.QIcon(sgtk.platform.current_engine().icon_256)
         self._is_quitting = False
 
@@ -631,12 +630,13 @@ class DesktopWindow(SystrayWindow):
         if self._is_quitting:
             return
         # Called when the dialog is disappearing.
-        has_warned_of_minimized_behaviour = self._settings_manager.retrieve(
+        has_warned_of_closed_behaviour = self._settings_manager.retrieve(
             "has_warned_of_closed_behaviour", False
         )
         # If we've never warned the user that closing the app dialog
         # sends it to the tray, do it.
-        if has_warned_of_minimized_behaviour is False:
+
+        if has_warned_of_closed_behaviour is False:
             # On macOS the app icon is already visible on the pop-up
             # message, do not show it a second time.
             # In Qt4, we can't have a custom icon, so don't display
@@ -645,6 +645,12 @@ class DesktopWindow(SystrayWindow):
                 icon = self.systray.NoIcon
             else:
                 icon = self._app_icon
+            # Note that on macOS+Qt4, this call will not show anything,
+            # at least on Catalina. This is likely because these builds predate
+            # Catalina and don't have the necessary APIs to request permission
+            # to use the Notification API and therefore fail at showing anything.
+            # It still works on Windows and Linux however for Desktop 1.5.x and
+            # lower.
             self.systray.showMessage(
                 "Shotgun Desktop",
                 "The application is now running in the system tray.",

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1666,6 +1666,7 @@ class DesktopWindow(SystrayWindow):
 
     def handle_about(self):
         engine = sgtk.platform.current_engine()
+
         # If a Startup version was specified when engine.run was invoked
         # it's because we're running the new installer code and therefore
         # we have a startup version to show.


### PR DESCRIPTION
The Shotgun Desktop will now be displayed unpinned by default the first time it is launched. This will reduce the confusion of first time users who do not understand where the app goes after the splash screen disappears.

Also, when a user clicks on the X or red button of the dialog, a pop-up will be shown the very first time letting the user know the app is now in the tray.

Finally, unhandled exceptions are now going to be logged. (FINALLY!!!!)

UPDATE after some QA tests:

I've rewired the chain of quitting operations in the Desktop. The Quit option in the menu instead calls quit on the QApplication and the handle_quit_action has been turned into a slot for the QApplication.aboutToQuit signal. This was necessary to handle macOS quirkyness when hitting CMD-Q properly. See the comments in closeEvent.

Note that this only works in the Qt5 build of Desktop. Qt4 build doesn't seem to support Catalina's notifcation/permission system.