### PR TITLE
Fix for restoring window position error

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -464,7 +464,13 @@ class DesktopWindow(SystrayWindow):
         pos = self._settings_manager.retrieve(
             "pos", QtCore.QPoint(200, 200), self._settings_manager.SCOPE_SITE
         )
-        self.move(pos)
+        try:
+            self.move(pos)
+        except TypeError:
+            # Its possible that we've loaded a PySide value,
+            # when we are using PySide2, in which case just ignore the setting.
+            pass
+
         # Force update so the project selection happens if the window is shown by default
         QtGui.QApplication.processEvents()
 


### PR DESCRIPTION
If the previous window position was stored as a PySide object it can sometimes end up getting through the `settings_manager.retrieve` and passed to PySide2, on which it then fails. This now just gracefully gives up on restoring the window position in this case.

Still needs testing, but getting this scenario is difficult and its not entirely clear how to replicate.