### PR TITLE
SG-11032 [tk-desktop] doesn't implement the host_info

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -61,7 +61,11 @@ class DesktopEngine(Engine):
         # Now continue with the standard initialization
         Engine.__init__(self, tk, *args, **kwargs)
 
-        self._host_info = {"name": "Desktop", "version": "unknown"}
+    def __new__(cls, *args, **kwargs):
+        # Assigning a default value to _host_info property during
+        # object creation.
+        cls._host_info = {"name": "Desktop", "version": "unknown"}
+        return super().__new__(cls, *args, **kwargs)
 
     @property
     def host_info(self):

--- a/python/tk_desktop/licenses.html
+++ b/python/tk_desktop/licenses.html
@@ -16,7 +16,7 @@
     </p>
     <p>
         <strong>Autodesk Trademarks</strong><br/>The trademarks on the <a
-            href="http://www.autodesk.com/company/legal-notices-trademarks/trademarks/autodesk-inc">Autodesk Trademarks
+            href="https://www.autodesk.com/company/legal-notices-trademarks/intellectual-property/trademarks">Autodesk Trademarks
         page</a> are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in
         the USA and/or other countries. &nbsp;&nbsp;All other brand names, product names or trademarks belong to their
         respective holders.


### PR DESCRIPTION
In order to assert a creation of _host_info attribute for each class or subclass instances, I added the method `__new__` to `DesktopEngine` class.