### PR TITLE
SG-11032 [tk-desktop] doesn't implement the host_info

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -65,7 +65,7 @@ class DesktopEngine(Engine):
         # Assigning a default value to _host_info property during
         # object creation.
         cls._host_info = {"name": "Desktop", "version": "unknown"}
-        return super().__new__(cls, *args, **kwargs)
+        return super().__new__(cls)
 
     @property
     def host_info(self):


### PR DESCRIPTION
In order to assert a creation of _host_info attribute for each class or subclass instances, I added the method __new__ to DesktopEngine class.