### PR TITLE
SG-31715 Engine Init Hook Cant Run QtguiQmessagebox

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -328,7 +328,10 @@ class DesktopEngineProjectImplementation(object):
                 # case just move on silently.
                 pass
 
-        app = QtGui.QApplication([])
+        app = QtGui.QApplication.instance()
+        if app is None:
+            # if it does not exist then a QApplication is created
+            app = QtGui.QApplication([])
 
         # We may launch multiple UI apps, do not quit as soon as the last one closes.
         app.setQuitOnLastWindowClosed(False)

--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -327,9 +327,11 @@ class DesktopEngineProjectImplementation(object):
                 # an older version of the installer that doesn't contain this package. In which
                 # case just move on silently.
                 pass
-
+        # If qt is already running and a QApplication has been
+        # initialized (e.g. on the engine_init core hook)
+        # let's create a Qt app instance.
         app = QtGui.QApplication.instance()
-        if app is None:
+        if not app:
             # if it does not exist then a QApplication is created
             app = QtGui.QApplication([])
 


### PR DESCRIPTION
This checks if Qt is already running and if a QApplication has been previously initialized. If not, it creates a Qt app instance. This fixes the RuntimeError that occurs silently in the desktop bootstrap when create any Qt application in the engine_init core hook.