### PR TITLE
SG-26914 Add banner centos 7 deprecation notice

### DIFF
--- a/python/tk_desktop/notifications/__init__.py
+++ b/python/tk_desktop/notifications/__init__.py
@@ -14,3 +14,4 @@ from .first_launch_notification import FirstLaunchNotification  # noqa
 from .desktop_notification import DesktopNotification  # noqa
 from .notification_manager import NotificationsManager  # noqa
 from .python2_deprecation_notification import Python2DeprecationNotification
+from .centos7_deprecation_notification import CentOS7DeprecationNotification

--- a/python/tk_desktop/notifications/centos7_deprecation_notification.py
+++ b/python/tk_desktop/notifications/centos7_deprecation_notification.py
@@ -128,8 +128,15 @@ class LinuxOSRelease:
     def load(self, filename="/etc/os-release"):
         try:
             file_data = open(filename).read()
-        except IOError:
-            logger.debug("Not an EL distribution")
+        except IOError as err:
+            logger.debug(
+                "Unable to open {filename}: {exc}".format(
+                    exc=err,
+                    filename=filename,
+                ),
+            )
+            logger.info("current OS is not a standard Linux distribution")
+
             return False
 
         config = configparser.ConfigParser()

--- a/python/tk_desktop/notifications/centos7_deprecation_notification.py
+++ b/python/tk_desktop/notifications/centos7_deprecation_notification.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2023 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from .notification import Notification
+import sgtk
+
+logger = sgtk.platform.get_logger(__name__)
+
+
+class CentOS7DeprecationNotification(Notification):
+    """
+    Notification for CentOS 7 deprecation.
+    """
+
+    _CENTOS7_DEPRECATION_ID = "centos7-deprecation-notification"
+
+    @classmethod
+    def create(cls, banner_settings):
+        """
+        Notification factory for CentOS 7 deprecation.
+
+        :param banner_settings: Dictionary of banner settings.
+
+        :returns: A :class:`CentOS7DeprecationNotification` instance, or ``None``.
+        """
+        if banner_settings.get(cls._CENTOS7_DEPRECATION_ID, False):
+            logger.debug("CentOS 7 banner has already been dismissed.")
+            return None
+        else:
+            logger.debug("CentOS 7 deprecation banner available")
+            return CentOS7DeprecationNotification()
+
+    @property
+    def message(self):
+        """
+        Message to display.
+        """
+
+        return """
+            ShotGrid is ending support for <b>CentOS 7</b> in SG Desktop on <b>June 2024</b>. Upgrade to <b>Rocky Linux 8</b>
+            before this date. Read more <a href="{url}">here</a>.
+        """.format(
+            url= "https://community.shotgridsoftware.com/t/    [[TODO]]",
+        )
+
+    @property
+    def unique_id(self):
+        """
+        Returns the unique identifier of a notification.
+        """
+        return self._CENTOS7_DEPRECATION_ID
+
+    def _dismiss(self, banner_settings):
+        """
+        Updates the ``banner_settings`` so this notification does not come back in the future.
+
+        :param banner_settings: Dictionary of the banners settings.
+        """
+        banner_settings[self._CENTOS7_DEPRECATION_ID] = True

--- a/python/tk_desktop/notifications/centos7_deprecation_notification.py
+++ b/python/tk_desktop/notifications/centos7_deprecation_notification.py
@@ -35,22 +35,30 @@ class CentOS7DeprecationNotification(Notification):
             logger.debug("CentOS 7 banner has already been dismissed.")
             return
 
-        if not sgtk.util.is_linux():
+        if not cls.is_el7():
             logger.debug("CentOS 7 banner is out of context in this OS.")
-            return
-
-        try:
-            os_data = open("/etc/os-release").read().lower()
-        except IOError:
-            logger.debug("CentOS 7 banner is out of context in this Linux distribution.")
-            return
-
-        if "centos" not in os_data and "7" not in os_data:
-            logger.debug("CentOS 7 banner is out of context in this Linux distribution (not a EL7 system).")
             return
 
         logger.debug("CentOS 7 deprecation banner available")
         return CentOS7DeprecationNotification()
+
+    @staticmethod
+    def is_el7():
+        if not sgtk.util.is_linux():
+            logger.debug("Not a Linux OS")
+            return False
+
+        try:
+            os_data = open("/etc/os-release").read().lower()
+        except IOError:
+            logger.debug("Not an EL distribution")
+            return False
+
+        if "centos" not in os_data and "7" not in os_data:
+            logger.debug("Not an EL7 distribution")
+            return False
+
+        return True
 
     @property
     def message(self):

--- a/python/tk_desktop/notifications/centos7_deprecation_notification.py
+++ b/python/tk_desktop/notifications/centos7_deprecation_notification.py
@@ -16,6 +16,7 @@ import sgtk
 
 logger = sgtk.platform.get_logger(__name__)
 
+
 class CentOS7DeprecationNotification(Notification):
     """
     Notification for CentOS 7 deprecation.
@@ -43,7 +44,6 @@ class CentOS7DeprecationNotification(Notification):
 
         logger.debug("CentOS 7 deprecation banner available")
         return CentOS7DeprecationNotification()
-
 
     @staticmethod
     def display_on_this_os(filename="/etc/os-release"):
@@ -134,7 +134,7 @@ class LinuxOSRelease:
 
         config = configparser.ConfigParser()
         try:
-            config.read_string("[root]\n"+file_data)
+            config.read_string("[root]\n" + file_data)
         except configparser.ParsingError:
             return False
 
@@ -155,7 +155,6 @@ class LinuxOSRelease:
         data = self.get_entry(name)
         return self.reg_split_list.split(data)
 
-
     def is_el_flavor(self):
         dist_ids = self.get_list_items("ID_LIKE")
         if "rhel" in dist_ids:
@@ -166,7 +165,6 @@ class LinuxOSRelease:
             return True
 
         return False
-
 
     def is_centos(self):
         if self.get_entry("ID") == "centos":

--- a/python/tk_desktop/notifications/centos7_deprecation_notification.py
+++ b/python/tk_desktop/notifications/centos7_deprecation_notification.py
@@ -44,10 +44,13 @@ class CentOS7DeprecationNotification(Notification):
         """
 
         return """
-            ShotGrid is ending support for <b>CentOS 7</b> in SG Desktop on <b>June 2024</b>. Upgrade to <b>Rocky Linux 8</b>
-            before this date. Read more <a href="{url}">here</a>.
+            ShotGrid is ending support for <b>CentOS</b> in SG Toolkit and
+            Desktop on <b>November 1st 2024</b>.
+            Update to <b>Rocky Linux 8.5+</b> before this date  to avoid
+            disruption.
+            Read more <a href="{url}">here</a>.
         """.format(
-            url= "https://community.shotgridsoftware.com/t/    [[TODO]]",
+            url="https://community.shotgridsoftware.com/t/important-notice-for-end-of-october-2024-end-of-support-for-centos-sg-toolkit-and-sg-desktop/",
         )
 
     @property

--- a/python/tk_desktop/notifications/centos7_deprecation_notification.py
+++ b/python/tk_desktop/notifications/centos7_deprecation_notification.py
@@ -115,9 +115,9 @@ class LinuxOSRelease:
     """
     Read the /etc/os-release and provide simple utily tools to identifies flavor
     and version of the Linux distribution
-    
+
     https://www.man7.org/linux/man-pages/man5/os-release.5.html
-    
+
     Use a INI reader and customize a bit... It would be better to load the file into a shell and read the environment ...
     """
 
@@ -134,11 +134,11 @@ class LinuxOSRelease:
 
         config = configparser.ConfigParser()
         try:
-            config.read_string("[root]\n"+file_data) # \nwwwww
+            config.read_string("[root]\n"+file_data)
         except configparser.ParsingError:
             return False
-        
-        self._config =  config["root"]
+
+        self._config = config["root"]
         return True
 
     def get_entry(self, name, default="", auto_lower=True):

--- a/python/tk_desktop/notifications/centos7_deprecation_notification.py
+++ b/python/tk_desktop/notifications/centos7_deprecation_notification.py
@@ -30,12 +30,27 @@ class CentOS7DeprecationNotification(Notification):
 
         :returns: A :class:`CentOS7DeprecationNotification` instance, or ``None``.
         """
+
         if banner_settings.get(cls._CENTOS7_DEPRECATION_ID, False):
             logger.debug("CentOS 7 banner has already been dismissed.")
-            return None
-        else:
-            logger.debug("CentOS 7 deprecation banner available")
-            return CentOS7DeprecationNotification()
+            return
+
+        if not sgtk.util.is_linux():
+            logger.debug("CentOS 7 banner is out of context in this OS.")
+            return
+
+        try:
+            os_data = open("/etc/os-release").read().lower()
+        except IOError:
+            logger.debug("CentOS 7 banner is out of context in this Linux distribution.")
+            return
+
+        if "centos" not in os_data and "7" not in os_data:
+            logger.debug("CentOS 7 banner is out of context in this Linux distribution (not a EL7 system).")
+            return
+
+        logger.debug("CentOS 7 deprecation banner available")
+        return CentOS7DeprecationNotification()
 
     @property
     def message(self):

--- a/python/tk_desktop/notifications/centos7_deprecation_notification.py
+++ b/python/tk_desktop/notifications/centos7_deprecation_notification.py
@@ -8,10 +8,13 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import configparser
+
+import platform
 import re
+import sys
 
 from .notification import Notification
+from . import platform_os_release
 import sgtk
 
 logger = sgtk.platform.get_logger(__name__)
@@ -46,8 +49,10 @@ class CentOS7DeprecationNotification(Notification):
         return CentOS7DeprecationNotification()
 
     @staticmethod
-    def display_on_this_os(filename="/etc/os-release"):
+    def display_on_this_os():
         """
+        rely on https://www.man7.org/linux/man-pages/man5/os-release.5.html
+
         returns True if OS is EL7. Any EL if version 7
         returns True if OS is CentOS. Any CentOS versions
         returns True if unable to identify the OS/flavor/version
@@ -57,24 +62,36 @@ class CentOS7DeprecationNotification(Notification):
             logger.debug("Not a Linux OS")
             return False
 
-        linux_util = LinuxOSRelease()
+        if sys.version_info[:2] < (3, 10):
+            platform_mod = platform_os_release
+        else:
+            platform_mod = platform
 
-        if not linux_util.load(filename):
-            # we know it's Linux but can't read the file: let's display the info
+        try:
+            info = platform_mod.freedesktop_os_release()
+        except OSError:
             return True
 
-        if not linux_util.is_el_flavor():
-            # We only support EL distributions so let's display the notification
+        if not info or "ID" not in info:
+            # we know it's Linux but unable to retrieve os-release info
             return True
 
-        if linux_util.is_centos():
-            # We only support EL distributions so let's display the notification
+        os_ids = [info["ID"]]
+        if "ID_LIKE" in info:
+            os_ids.extend(info.get("ID_LIKE", "").split())
+
+        if "rhel" not in os_ids:
+            # We only support EL distributions
             return True
 
-        # At this point, we know it's a EL but not CentOS
-        # we want to match everything version 7
-        version_tuple = linux_util.get_entry("VERSION_ID", default="0").split(".")
-        if version_tuple[0] == "7" or linux_util.get_entry("CPE_NAME").endswith(":7"):
+        if info["ID"] == "centos":
+            # CentOS 7 will be the last supported distribution version
+            return True
+
+        # At this point, we know it's EL but not CentOS
+
+        if re.match("^7(\\.\\d.*)?$", info.get("VERSION_ID", "")):
+            # EL7 system
             return True
 
         return False
@@ -109,75 +126,3 @@ class CentOS7DeprecationNotification(Notification):
         :param banner_settings: Dictionary of the banners settings.
         """
         banner_settings[self._CENTOS7_DEPRECATION_ID] = True
-
-
-class LinuxOSRelease:
-    """
-    Read the /etc/os-release and provide simple utily tools to identifies flavor
-    and version of the Linux distribution
-
-    https://www.man7.org/linux/man-pages/man5/os-release.5.html
-
-    Use a INI reader and customize a bit... It would be better to load the file into a shell and read the environment ...
-    """
-
-    def __init__(self):
-        self._config = None
-        self.reg_split_list = re.compile(" +")
-
-    def load(self, filename="/etc/os-release"):
-        try:
-            file_data = open(filename).read()
-        except IOError as err:
-            logger.debug(
-                "Unable to open {filename}: {exc}".format(
-                    exc=err,
-                    filename=filename,
-                ),
-            )
-            logger.info("current OS is not a standard Linux distribution")
-
-            return False
-
-        config = configparser.ConfigParser()
-        try:
-            config.read_string("[root]\n" + file_data)
-        except configparser.ParsingError:
-            return False
-
-        self._config = config["root"]
-        return True
-
-    def get_entry(self, name, default="", auto_lower=True):
-        data = self._config.get(name, default)
-        if data.strip().startswith('"') and data.strip().endswith('"'):
-            data = data[1:-1]
-
-        if auto_lower:
-            data = data.lower()
-
-        return data
-
-    def get_list_items(self, name):
-        data = self.get_entry(name)
-        return self.reg_split_list.split(data)
-
-    def is_el_flavor(self):
-        dist_ids = self.get_list_items("ID_LIKE")
-        if "rhel" in dist_ids:
-            return True
-
-        platform_id = self.get_entry("PLATFORM_ID")
-        if platform_id.startswith("platform:el"):
-            return True
-
-        return False
-
-    def is_centos(self):
-        if self.get_entry("ID") == "centos":
-            return True
-
-        if ":centos:" in self.get_entry("CPE_NAME"):
-            return True
-
-        return False

--- a/python/tk_desktop/notifications/notification_manager.py
+++ b/python/tk_desktop/notifications/notification_manager.py
@@ -27,7 +27,6 @@ class NotificationsManager(object):
 
     _BANNERS = "banners"
     NOTIFS_TO_BE_INCLUDED_IN_FIRST_LAUNCH = [
-        CentOS7DeprecationNotification,
         Python2DeprecationNotification,
     ]
 

--- a/python/tk_desktop/notifications/notification_manager.py
+++ b/python/tk_desktop/notifications/notification_manager.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .desktop_notification import DesktopNotification
+from .centos7_deprecation_notification import CentOS7DeprecationNotification
 from .configuration_update_notification import ConfigurationUpdateNotification
 from .first_launch_notification import FirstLaunchNotification
 from .startup_update_notification import StartupUpdateNotification
@@ -26,6 +27,7 @@ class NotificationsManager(object):
 
     _BANNERS = "banners"
     NOTIFS_TO_BE_INCLUDED_IN_FIRST_LAUNCH = [
+        CentOS7DeprecationNotification,
         Python2DeprecationNotification,
     ]
 
@@ -59,6 +61,7 @@ class NotificationsManager(object):
         first_launch_notif = FirstLaunchNotification.create(banner_settings)
         # Python 2 deprecation notif
         python2_notif = Python2DeprecationNotification.create(banner_settings)
+
         # startup update and desktop notifs
         startup_update_notif = StartupUpdateNotification.create(
             banner_settings, self._engine
@@ -72,6 +75,9 @@ class NotificationsManager(object):
             startup_update_notif,
             desktop_notif,
             python2_notif,
+
+            # CentOS 7 deprecation notif
+            CentOS7DeprecationNotification.create(banner_settings),
         ]
 
         # If both descriptors are set and they have the same uri, we only want one notification.

--- a/python/tk_desktop/notifications/notification_manager.py
+++ b/python/tk_desktop/notifications/notification_manager.py
@@ -75,7 +75,6 @@ class NotificationsManager(object):
             startup_update_notif,
             desktop_notif,
             python2_notif,
-
             # CentOS 7 deprecation notif
             CentOS7DeprecationNotification.create(banner_settings),
         ]

--- a/python/tk_desktop/notifications/platform_os_release.py
+++ b/python/tk_desktop/notifications/platform_os_release.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2024 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+# This is a backpost of Python 3.10's platform module
+
+import re
+
+### freedesktop.org os-release standard
+# https://www.freedesktop.org/software/systemd/man/os-release.html
+
+# NAME=value with optional quotes (' or "). The regular expression is less
+# strict than shell lexer, but that's ok.
+_os_release_line = re.compile(
+    "^(?P<name>[a-zA-Z0-9_]+)=(?P<quote>[\"']?)(?P<value>.*)(?P=quote)$"
+)
+# unescape five special characters mentioned in the standard
+_os_release_unescape = re.compile(r"\\([\\\$\"\'`])")
+# /etc takes precedence over /usr/lib
+_os_release_candidates = ("/etc/os-release", "/usr/lib/os-release")
+_os_release_cache = None
+
+
+def _parse_os_release(lines):
+    # These fields are mandatory fields with well-known defaults
+    # in practice all Linux distributions override NAME, ID, and PRETTY_NAME.
+    info = {
+        "NAME": "Linux",
+        "ID": "linux",
+        "PRETTY_NAME": "Linux",
+    }
+
+    for line in lines:
+        mo = _os_release_line.match(line)
+        if mo is not None:
+            info[mo.group("name")] = _os_release_unescape.sub(r"\1", mo.group("value"))
+
+    return info
+
+
+def freedesktop_os_release():
+    """Return operation system identification from freedesktop.org os-release"""
+    global _os_release_cache
+
+    if _os_release_cache is None:
+        errno = None
+        for candidate in _os_release_candidates:
+            try:
+                with open(candidate, encoding="utf-8") as f:
+                    _os_release_cache = _parse_os_release(f)
+                break
+            except OSError as e:
+                errno = e.errno
+        else:
+            raise OSError(
+                errno, f"Unable to read files {', '.join(_os_release_candidates)}"
+            )
+
+    return _os_release_cache.copy()

--- a/python/tk_desktop/notifications/platform_os_release.py
+++ b/python/tk_desktop/notifications/platform_os_release.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 
-# This is a backpost of Python 3.10's platform module
+# This is a backport of Python 3.10's platform module
 
 import re
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -256,4 +256,4 @@ class TestNotifications(TankTestBase):
 
             self._notification_manager.dismiss(notif)
 
-        self.assertTrue(is_included)
+        # self.assertTrue(is_included) # does not work ...

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -250,7 +250,7 @@ class TestNotifications(TankTestBase):
             },
         ), mock.patch.object(
             notifications.CentOS7DeprecationNotification,
-            "is_el7",
+            "display_on_this_os",
             return_value=True,
         ):
             notifs = self._notification_manager.get_notifications()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -10,7 +10,7 @@
 
 from __future__ import with_statement
 
-from tank_test.tank_test_base import TankTestBase, SealedMock
+from tank_test.tank_test_base import TankTestBase, SealedMock, mock
 from tank_test.tank_test_base import setUpModule  # noqa
 
 import notifications
@@ -242,12 +242,12 @@ class TestNotifications(TankTestBase):
         Test CentOS7 deprecation notification.
         """
 
-        bak_is_el7 = notifications.CentOS7DeprecationNotification.is_el7
-        notifications.CentOS7DeprecationNotification.is_el7 = lambda: True
-        try:
+        with mock.patch.object(
+            notifications.CentOS7DeprecationNotification,
+            "is_el7",
+            return_value=True,
+        ) as mock_method:
             notifs = self._notification_manager.get_notifications()
-        finally:
-            notifications.CentOS7DeprecationNotification.is_el7 = bak_is_el7
 
         is_included = False
         for notif in notifs:
@@ -256,4 +256,4 @@ class TestNotifications(TankTestBase):
 
             self._notification_manager.dismiss(notif)
 
-        # self.assertTrue(is_included) # does not work ...
+        self.assertTrue(is_included)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -243,10 +243,16 @@ class TestNotifications(TankTestBase):
         """
 
         with mock.patch.object(
+            self._notification_manager,
+            "_get_banner_settings",
+            return_value={
+                notifications.FirstLaunchNotification._FIRST_LAUNCH_BANNER_VIEWED_ID: True,
+            },
+        ), mock.patch.object(
             notifications.CentOS7DeprecationNotification,
             "is_el7",
             return_value=True,
-        ) as mock_method:
+        ):
             notifs = self._notification_manager.get_notifications()
 
         is_included = False

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -241,7 +241,13 @@ class TestNotifications(TankTestBase):
         """
         Test CentOS7 deprecation notification.
         """
-        notifs = self._notification_manager.get_notifications()
+
+        bak_is_el7 = notifications.CentOS7DeprecationNotification.is_el7
+        notifications.CentOS7DeprecationNotification.is_el7 = lambda: True
+        try:
+            notifs = self._notification_manager.get_notifications()
+        finally:
+            notifications.CentOS7DeprecationNotification.is_el7 = bak_is_el7
 
         is_included = False
         for notif in notifs:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -236,3 +236,18 @@ class TestNotifications(TankTestBase):
             self._notification_manager.dismiss(notif)
 
         self.assertTrue(is_included)
+
+    def test_centos7_deprecation_notifs(self):
+        """
+        Test CentOS7 deprecation notification.
+        """
+        notifs = self._notification_manager.get_notifications()
+
+        is_included = False
+        for notif in notifs:
+            if isinstance(notif, notifications.CentOS7DeprecationNotification):
+                is_included = True
+
+            self._notification_manager.dismiss(notif)
+
+        self.assertTrue(is_included)

--- a/tests/test_notifications_el7.py
+++ b/tests/test_notifications_el7.py
@@ -50,8 +50,6 @@ class TestNotificationsEL7(TankTestBase):
 
     @contextlib.contextmanager
     def patch_platform_os_release_candidates(self, data):
-        # TODO: if python < 3.10: use .... instead of platform
-
         os_release_candidates_back = self.platform_mod._os_release_cache
         self.platform_mod._os_release_cache = None
 

--- a/tests/test_notifications_el7.py
+++ b/tests/test_notifications_el7.py
@@ -21,10 +21,7 @@ class TestNotificationsEL7(TankTestBase):
             "sgtk.util.is_linux",
             return_value=False,
         ):
-            self.assertFalse(
-                CentOS7DeprecationNotification.display_on_this_os()
-            )
-
+            self.assertFalse(CentOS7DeprecationNotification.display_on_this_os())
 
     @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_file_does_not_exist(self, *patches):
@@ -48,7 +45,8 @@ class TestNotificationsEL7(TankTestBase):
     @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_not_el_flavor(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
-            f.write("""
+            f.write(
+                """
 PRETTY_NAME="Ubuntu 23.10"
 NAME="Ubuntu"
 VERSION_ID="23.10"
@@ -62,7 +60,8 @@ BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
 PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
 UBUNTU_CODENAME=mantic
 LOGO=ubuntu-logo
-""")
+"""
+            )
             f.flush()
             self.assertTrue(
                 CentOS7DeprecationNotification.display_on_this_os(
@@ -73,7 +72,8 @@ LOGO=ubuntu-logo
     @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_centos7(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
-            f.write("""
+            f.write(
+                """
 NAME="CentOS Linux"
 VERSION="7 (Core)"
 ID="centos"
@@ -89,7 +89,8 @@ CENTOS_MANTISBT_PROJECT="CentOS-7"
 CENTOS_MANTISBT_PROJECT_VERSION="7"
 REDHAT_SUPPORT_PRODUCT="centos"
 REDHAT_SUPPORT_PRODUCT_VERSION="7"
-""")
+"""
+            )
             f.flush()
             self.assertTrue(
                 CentOS7DeprecationNotification.display_on_this_os(
@@ -100,7 +101,8 @@ REDHAT_SUPPORT_PRODUCT_VERSION="7"
     @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_centos88(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
-            f.write("""
+            f.write(
+                """
 NAME="CentOS Linux"
 VERSION="88 (Core)"
 ID="centos"
@@ -116,7 +118,8 @@ CENTOS_MANTISBT_PROJECT="CentOS-88"
 CENTOS_MANTISBT_PROJECT_VERSION="88"
 REDHAT_SUPPORT_PRODUCT="centos"
 REDHAT_SUPPORT_PRODUCT_VERSION="88"
-""")
+"""
+            )
             f.flush()
             self.assertTrue(
                 CentOS7DeprecationNotification.display_on_this_os(
@@ -127,7 +130,8 @@ REDHAT_SUPPORT_PRODUCT_VERSION="88"
     @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_rocky8(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
-            f.write("""
+            f.write(
+                """
 NAME="Rocky Linux"
 VERSION="8.8 (Green Obsidian)"
 ID="rocky"
@@ -145,7 +149,8 @@ ROCKY_SUPPORT_PRODUCT="Rocky-Linux-8"
 ROCKY_SUPPORT_PRODUCT_VERSION="8.8"
 REDHAT_SUPPORT_PRODUCT="Rocky Linux"
 REDHAT_SUPPORT_PRODUCT_VERSION="8.8"
-""")
+"""
+            )
             f.flush()
             self.assertFalse(
                 CentOS7DeprecationNotification.display_on_this_os(
@@ -156,7 +161,8 @@ REDHAT_SUPPORT_PRODUCT_VERSION="8.8"
     @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_rocky9(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
-            f.write("""
+            f.write(
+                """
 NAME="Rocky Linux"
 VERSION="9.3 (Blue Onyx)"
 ID="rocky"
@@ -174,7 +180,8 @@ ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
 ROCKY_SUPPORT_PRODUCT_VERSION="9.3"
 REDHAT_SUPPORT_PRODUCT="Rocky Linux"
 REDHAT_SUPPORT_PRODUCT_VERSION="9.3"
-""")
+"""
+            )
             f.flush()
             self.assertFalse(
                 CentOS7DeprecationNotification.display_on_this_os(
@@ -185,7 +192,8 @@ REDHAT_SUPPORT_PRODUCT_VERSION="9.3"
     @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_rhel7(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
-            f.write("""
+            f.write(
+                """
 NAME="Red Hat Enterprise Linux"
 VERSION="7 (Core)"
 ID="rhel"
@@ -196,7 +204,8 @@ CPE_NAME="cpe:/o:rhel:rhel:7"
 
 REDHAT_SUPPORT_PRODUCT="rhel"
 REDHAT_SUPPORT_PRODUCT_VERSION="7"
-""")
+"""
+            )
             f.flush()
             self.assertTrue(
                 CentOS7DeprecationNotification.display_on_this_os(
@@ -207,12 +216,14 @@ REDHAT_SUPPORT_PRODUCT_VERSION="7"
     @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_weird_el7(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
-            f.write("""
+            f.write(
+                """
 NAME="Weird Dist"
 ID="weird"
 VERSION_ID="7.7"
 PLATFORM_ID="platform:el7"
-""")
+"""
+            )
             f.flush()
             self.assertTrue(
                 CentOS7DeprecationNotification.display_on_this_os(

--- a/tests/test_notifications_el7.py
+++ b/tests/test_notifications_el7.py
@@ -12,18 +12,30 @@ from tank_test.tank_test_base import TankTestBase, mock
 from tank_test.tank_test_base import setUpModule  # noqa
 
 from notifications import CentOS7DeprecationNotification
+
+import os
+import sys
 import tempfile
+import unittest
 
 
-class TestNotificationsEL7(TankTestBase):
-    def test_not_linux_os(self):
+class TestNotificationsEL7_NotLinux(TankTestBase):
+    def test(self):
         with mock.patch(
             "sgtk.util.is_linux",
             return_value=False,
         ):
             self.assertFalse(CentOS7DeprecationNotification.display_on_this_os())
 
-    @mock.patch("sgtk.util.is_linux", return_value=True)
+
+@unittest.skipIf(
+    sys.platform.startswith("win"),
+    "Test does not work on Windows (permission denied when accessing opening a"
+    "NamedTemporaryFile file)"
+    "No problem: we tested useless test anyway",
+)
+@mock.patch("sgtk.util.is_linux", return_value=True)
+class TestNotificationsEL7(TankTestBase):
     def test_file_does_not_exist(self, *patches):
         self.assertTrue(
             CentOS7DeprecationNotification.display_on_this_os(
@@ -31,7 +43,6 @@ class TestNotificationsEL7(TankTestBase):
             )
         )
 
-    @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_file_is_not_ini(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
             f.write("not an INI file")
@@ -42,7 +53,6 @@ class TestNotificationsEL7(TankTestBase):
                 )
             )
 
-    @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_not_el_flavor(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
             f.write(
@@ -69,7 +79,6 @@ LOGO=ubuntu-logo
                 )
             )
 
-    @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_centos7(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
             f.write(
@@ -98,7 +107,6 @@ REDHAT_SUPPORT_PRODUCT_VERSION="7"
                 )
             )
 
-    @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_centos88(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
             f.write(
@@ -127,7 +135,6 @@ REDHAT_SUPPORT_PRODUCT_VERSION="88"
                 )
             )
 
-    @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_rocky8(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
             f.write(
@@ -158,7 +165,6 @@ REDHAT_SUPPORT_PRODUCT_VERSION="8.8"
                 )
             )
 
-    @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_rocky9(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
             f.write(
@@ -189,7 +195,6 @@ REDHAT_SUPPORT_PRODUCT_VERSION="9.3"
                 )
             )
 
-    @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_rhel7(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
             f.write(
@@ -213,7 +218,6 @@ REDHAT_SUPPORT_PRODUCT_VERSION="7"
                 )
             )
 
-    @mock.patch("sgtk.util.is_linux", return_value=True)
     def test_is_weird_el7(self, *patches):
         with tempfile.NamedTemporaryFile(mode="w+") as f:
             f.write(

--- a/tests/test_notifications_el7.py
+++ b/tests/test_notifications_el7.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2024 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from tank_test.tank_test_base import TankTestBase, mock
+from tank_test.tank_test_base import setUpModule  # noqa
+
+from notifications import CentOS7DeprecationNotification
+import tempfile
+
+
+class TestNotificationsEL7(TankTestBase):
+    def test_not_linux_os(self):
+        with mock.patch(
+            "sgtk.util.is_linux",
+            return_value=False,
+        ):
+            self.assertFalse(
+                CentOS7DeprecationNotification.display_on_this_os()
+            )
+
+
+    @mock.patch("sgtk.util.is_linux", return_value=True)
+    def test_file_does_not_exist(self, *patches):
+        self.assertTrue(
+            CentOS7DeprecationNotification.display_on_this_os(
+                filename="file_does_not_exist"
+            )
+        )
+
+    @mock.patch("sgtk.util.is_linux", return_value=True)
+    def test_file_is_not_ini(self, *patches):
+        with tempfile.NamedTemporaryFile(mode="w+") as f:
+            f.write("not an INI file")
+            f.flush()
+            self.assertTrue(
+                CentOS7DeprecationNotification.display_on_this_os(
+                    filename=f.name,
+                )
+            )
+
+    @mock.patch("sgtk.util.is_linux", return_value=True)
+    def test_is_not_el_flavor(self, *patches):
+        with tempfile.NamedTemporaryFile(mode="w+") as f:
+            f.write("""
+PRETTY_NAME="Ubuntu 23.10"
+NAME="Ubuntu"
+VERSION_ID="23.10"
+VERSION="23.10 (Mantic Minotaur)"
+VERSION_CODENAME=mantic
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=mantic
+LOGO=ubuntu-logo
+""")
+            f.flush()
+            self.assertTrue(
+                CentOS7DeprecationNotification.display_on_this_os(
+                    filename=f.name,
+                )
+            )
+
+    @mock.patch("sgtk.util.is_linux", return_value=True)
+    def test_is_centos7(self, *patches):
+        with tempfile.NamedTemporaryFile(mode="w+") as f:
+            f.write("""
+NAME="CentOS Linux"
+VERSION="7 (Core)"
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="7"
+PRETTY_NAME="CentOS Linux 7 (Core)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:centos:centos:7"
+HOME_URL="https://www.centos.org/"
+BUG_REPORT_URL="https://bugs.centos.org/"
+
+CENTOS_MANTISBT_PROJECT="CentOS-7"
+CENTOS_MANTISBT_PROJECT_VERSION="7"
+REDHAT_SUPPORT_PRODUCT="centos"
+REDHAT_SUPPORT_PRODUCT_VERSION="7"
+""")
+            f.flush()
+            self.assertTrue(
+                CentOS7DeprecationNotification.display_on_this_os(
+                    filename=f.name,
+                )
+            )
+
+    @mock.patch("sgtk.util.is_linux", return_value=True)
+    def test_is_centos88(self, *patches):
+        with tempfile.NamedTemporaryFile(mode="w+") as f:
+            f.write("""
+NAME="CentOS Linux"
+VERSION="88 (Core)"
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="88"
+PRETTY_NAME="CentOS Linux 88 (Core)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:centos:centos:88"
+HOME_URL="https://www.centos.org/"
+BUG_REPORT_URL="https://bugs.centos.org/"
+
+CENTOS_MANTISBT_PROJECT="CentOS-88"
+CENTOS_MANTISBT_PROJECT_VERSION="88"
+REDHAT_SUPPORT_PRODUCT="centos"
+REDHAT_SUPPORT_PRODUCT_VERSION="88"
+""")
+            f.flush()
+            self.assertTrue(
+                CentOS7DeprecationNotification.display_on_this_os(
+                    filename=f.name,
+                )
+            )
+
+    @mock.patch("sgtk.util.is_linux", return_value=True)
+    def test_is_rocky8(self, *patches):
+        with tempfile.NamedTemporaryFile(mode="w+") as f:
+            f.write("""
+NAME="Rocky Linux"
+VERSION="8.8 (Green Obsidian)"
+ID="rocky"
+ID_LIKE="rhel centos fedora"
+VERSION_ID="8.8"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="Rocky Linux 8.8 (Green Obsidian)"
+ANSI_COLOR="0;32"
+LOGO="fedora-logo-icon"
+CPE_NAME="cpe:/o:rocky:rocky:8:GA"
+HOME_URL="https://rockylinux.org/"
+BUG_REPORT_URL="https://bugs.rockylinux.org/"
+SUPPORT_END="2029-05-31"
+ROCKY_SUPPORT_PRODUCT="Rocky-Linux-8"
+ROCKY_SUPPORT_PRODUCT_VERSION="8.8"
+REDHAT_SUPPORT_PRODUCT="Rocky Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="8.8"
+""")
+            f.flush()
+            self.assertFalse(
+                CentOS7DeprecationNotification.display_on_this_os(
+                    filename=f.name,
+                )
+            )
+
+    @mock.patch("sgtk.util.is_linux", return_value=True)
+    def test_is_rocky9(self, *patches):
+        with tempfile.NamedTemporaryFile(mode="w+") as f:
+            f.write("""
+NAME="Rocky Linux"
+VERSION="9.3 (Blue Onyx)"
+ID="rocky"
+ID_LIKE="rhel centos fedora"
+VERSION_ID="9.3"
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="Rocky Linux 9.3 (Blue Onyx)"
+ANSI_COLOR="0;32"
+LOGO="fedora-logo-icon"
+CPE_NAME="cpe:/o:rocky:rocky:9::baseos"
+HOME_URL="https://rockylinux.org/"
+BUG_REPORT_URL="https://bugs.rockylinux.org/"
+SUPPORT_END="2032-05-31"
+ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
+ROCKY_SUPPORT_PRODUCT_VERSION="9.3"
+REDHAT_SUPPORT_PRODUCT="Rocky Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="9.3"
+""")
+            f.flush()
+            self.assertFalse(
+                CentOS7DeprecationNotification.display_on_this_os(
+                    filename=f.name,
+                )
+            )
+
+    @mock.patch("sgtk.util.is_linux", return_value=True)
+    def test_is_rhel7(self, *patches):
+        with tempfile.NamedTemporaryFile(mode="w+") as f:
+            f.write("""
+NAME="Red Hat Enterprise Linux"
+VERSION="7 (Core)"
+ID="rhel"
+ID_LIKE="rhel"
+VERSION_ID="7"
+PRETTY_NAME="Red Hat Enterprise Linux 7 (Core)"
+CPE_NAME="cpe:/o:rhel:rhel:7"
+
+REDHAT_SUPPORT_PRODUCT="rhel"
+REDHAT_SUPPORT_PRODUCT_VERSION="7"
+""")
+            f.flush()
+            self.assertTrue(
+                CentOS7DeprecationNotification.display_on_this_os(
+                    filename=f.name,
+                )
+            )
+
+    @mock.patch("sgtk.util.is_linux", return_value=True)
+    def test_is_weird_el7(self, *patches):
+        with tempfile.NamedTemporaryFile(mode="w+") as f:
+            f.write("""
+NAME="Weird Dist"
+ID="weird"
+VERSION_ID="7.7"
+PLATFORM_ID="platform:el7"
+""")
+            f.flush()
+            self.assertTrue(
+                CentOS7DeprecationNotification.display_on_this_os(
+                    filename=f.name,
+                )
+            )


### PR DESCRIPTION
Create a new banner to announce the end of support for CentOS 7.

Display the banner only on Linux. But not on Rocky 8 or any EL8. We display the banner on:
- Any Linux that is not EL
- Any EL7
- Any unknown Linux