### PR TITLE
SG-35333 Fix broken NoAppsInstalledOverlay layout

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -6,15 +6,6 @@
 
 # expected fields in the configuration file for this engine
 configuration:
-    # NOTE: The 'sg_software_entity' setting is only temporary and
-    #       will be removed once the Software entity becomes native
-    #       in Shotgun
-    sg_software_entity:
-        type: str
-        description: Flow Production Tracking CustomNonProjectEntity designated as the
-                     Software entity until it becomes native.
-        default_value: CustomNonProjectEntity23
-
     software_entity_config_link:
         type: str
         description: Link to a Flow Production Tracking Support article detailing how to

--- a/python/tk_desktop/no_apps_installed_overlay.py
+++ b/python/tk_desktop/no_apps_installed_overlay.py
@@ -172,7 +172,7 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
 
     def _get_sg_software_entities(self, engine, project=None):
         """
-        Retrieve a list of Software entities from Shotgun that
+        Retrieve a list of Software entities from FPTR that
         are active for the current project and user.
 
         If the shotgun connection does not support software entities,

--- a/python/tk_desktop/no_apps_installed_overlay.py
+++ b/python/tk_desktop/no_apps_installed_overlay.py
@@ -270,7 +270,6 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
 
         return sg_softwares
 
-
     def __get_sg_server_version(self, engine):
         """
         Retrieves the shotgun server version

--- a/python/tk_desktop/no_apps_installed_overlay.py
+++ b/python/tk_desktop/no_apps_installed_overlay.py
@@ -172,15 +172,21 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
 
     def _get_sg_software_entities(self, engine, project=None):
         """
-        Retrieve Software entities from Shotgun for the specified Project.
+        Retrieve a list of Software entities from Shotgun that
+        are active for the current project and user.
+
+        If the shotgun connection does not support software entities,
+        a none value is returned.
 
         :param engine: Toolkit engine instance
         :param project: Shotgun Project instance.
         """
-        # @TODO: Remove this when Software entities are native.
-        sw_entity = engine.get_setting("sg_software_entity")
-        if not sw_entity:
-            engine.logger.warning("Unable to determine Software CustomEntity.")
+
+        # check that software entity is supported
+        if self.__get_sg_server_version(engine) < (7, 2, 0):
+            engine.logger.log_warning(
+                "Your version of PTR does not support Software entity based launching."
+            )
             return
 
         # Use filters to retrieve Software entities that match specified
@@ -197,18 +203,18 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
 
         # Next handle Project restrictions. Always include Software entities
         # that have no Project restrictions.
-        project_filters = [["sg_projects", "is", None]]
+        project_filters = [["projects", "is", None]]
         current_project = project or engine.context.project
         if current_project:
             # If a Project is defined in the current context, retrieve
             # Software entities that have either no Project restrictions OR
             # include the context Project as a restriction.
             project_filters.append(
-                ["sg_projects", "in", current_project],
+                ["projects", "in", current_project],
             )
             sw_filters.append(
                 {
-                    "filter_operator": "or",
+                    "filter_operator": "any",
                     "filters": project_filters,
                 }
             )
@@ -220,10 +226,7 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
         # Now Group and User restrictions. Always retrieve Software entities
         # that have no Group or User restrictions.
         current_user = engine.context.user
-        user_group_filters = [
-            ["sg_user_restrictions", "is", None],
-            ["sg_group_restrictions", "is", None],
-        ]
+        user_group_filter = ["user_restrictions", "is", None]
         if current_user:
             # If a current User is defined, then retrieve Software
             # entities that either have A) no Group AND no User
@@ -231,15 +234,15 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
             # OR User restrictions.
             sw_filters.append(
                 {
-                    "filter_operator": "or",
+                    "filter_operator": "any",
                     "filters": [
-                        {"filter_operator": "and", "filters": user_group_filters},
+                        user_group_filter,
                         {
-                            "filter_operator": "or",
+                            "filter_operator": "any",
                             "filters": [
-                                ["sg_user_restrictions", "in", current_user],
+                                ["user_restrictions", "in", current_user],
                                 [
-                                    "sg_group_restrictions.Group.users",
+                                    "user_restrictions.Group.users",
                                     "in",
                                     current_user,
                                 ],
@@ -251,10 +254,10 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
         else:
             # If no User is defined, then only retrieve Software
             # entities that do not have any Group or User restrictions.
-            sw_filters.extend(user_group_filters)
+            sw_filters.append(user_group_filter)
 
         # Get the list of matching Software entities
-        sg_softwares = engine.shotgun.find(sw_entity, sw_filters)
+        sg_softwares = engine.shotgun.find("Software", sw_filters)
         engine.logger.debug(
             "Found [%d] Software entities matching filters: %s"
             % (len(sg_softwares), pprint.pformat(sw_filters))
@@ -266,3 +269,16 @@ class NoAppsInstalledOverlay(QtGui.QWidget):
             return
 
         return sg_softwares
+
+
+    def __get_sg_server_version(self, engine):
+        """
+        Retrieves the shotgun server version
+        from the currently connected Shotgun.
+
+        :returns: Tuple of (major, minor, patch) versions.
+        """
+        sg_major_ver = engine.shotgun.server_info["version"][0]
+        sg_minor_ver = engine.shotgun.server_info["version"][1]
+        sg_patch_ver = engine.shotgun.server_info["version"][2]
+        return sg_major_ver, sg_minor_ver, sg_patch_ver

--- a/python/tk_desktop/ui/no_apps_installed_overlay.py
+++ b/python/tk_desktop/ui/no_apps_installed_overlay.py
@@ -91,7 +91,7 @@ class Ui_NoAppsInstalledOverlay(object):
         NoAppsInstalledOverlay.setWindowTitle(QtGui.QApplication.translate("NoAppsInstalledOverlay", "Form", None, QtGui.QApplication.UnicodeUTF8))
         self.main_label.setText(QtGui.QApplication.translate("NoAppsInstalledOverlay", "We couldn\'t find anything to launch.", None, QtGui.QApplication.UnicodeUTF8))
         self.sub_label_1.setText(QtGui.QApplication.translate("NoAppsInstalledOverlay", "Install a supported", None, QtGui.QApplication.UnicodeUTF8))
-        self.sub_label_2.setText(QtGui.QApplication.translate("NoAppsInstalledOverlay", "application to start using it with Flow Production Tracking.", None, QtGui.QApplication.UnicodeUTF8))
+        self.sub_label_2.setText(QtGui.QApplication.translate("NoAppsInstalledOverlay", "application to start using it with FPTR.", None, QtGui.QApplication.UnicodeUTF8))
         self.link_label.setText(QtGui.QApplication.translate("NoAppsInstalledOverlay", "Click here to find out how to configure this screen.", None, QtGui.QApplication.UnicodeUTF8))
 
 from . import resources_rc

--- a/resources/no_apps_installed_overlay.ui
+++ b/resources/no_apps_installed_overlay.ui
@@ -128,7 +128,7 @@
           <string notr="true">font-size: 18px; color: #888888</string>
          </property>
          <property name="text">
-          <string>application to start using it with Flow Production Tracking.</string>
+          <string>application to start using it with FPTR.</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>


### PR DESCRIPTION
The CustomNonProjectEntity23 entity is long gone and has been replaced by the Software entity since SG version 7.2.

Fixing the behavior by re-aligning the function behavior with the implementation in tk-multi-launchapp: https://github.com/shotgunsoftware/tk-multi-launchapp/blob/v0.13.0/python/tk_multi_launchapp/software_entity_launcher.py#L204