### PR TITLE
SG-35325 Prevent flaky tests

### DIFF
--- a/python/tk_desktop/rpc.py
+++ b/python/tk_desktop/rpc.py
@@ -17,7 +17,7 @@ import threading
 import time
 import traceback
 import multiprocessing.connection
-from  multiprocessing.context import AuthenticationError
+from multiprocessing.context import AuthenticationError
 
 # We have to import Python's pickle to serialize our data.
 # tk-core's sgtk.util.pickle module assumes too much about the data

--- a/python/tk_desktop/rpc.py
+++ b/python/tk_desktop/rpc.py
@@ -272,7 +272,7 @@ class RPCServerThread(threading.Thread):
                     )
                     ready = True
                 except AttributeError as e:
-                    # The server has been closed.
+                    # The server has been closed. `_listener` is None.
                     logger.debug("Error during select:", exc_info=True)
                     if self.server._listener:
                         raise
@@ -293,7 +293,7 @@ class RPCServerThread(threading.Thread):
                     )
                     ready = len(rd) > 0
                 except AttributeError as e:
-                    # The server has been closed.
+                    # The server has been closed. `_listener` is None.
                     logger.debug("Error during select:", exc_info=True)
                     if self.server._listener:
                         raise
@@ -469,8 +469,8 @@ class RPCProxy(object):
                 if self._closed:
                     raise RuntimeError("client closed while waiting for a response")
 
-                # Check if there's a WinError that causes flaky behavior on CI
-                if sys.platform == "win32":
+                # Check if there's a WinError that causes some flaky behavior on CI
+                if sys.platform == "win32" and "The handle is invalid" in str(e):
                     import _winapi
 
                     if e.winerror:

--- a/python/tk_desktop/rpc.py
+++ b/python/tk_desktop/rpc.py
@@ -464,13 +464,8 @@ class RPCProxy(object):
                     if self._closed:
                         raise RuntimeError("client closed while waiting for a response")
                     continue
-            except IOError:
-                # An exception is raised on Windows when the connection
-                # is closed during polling instead of simply returning False.
-                if self._closed:
-                    raise RuntimeError("client closed while waiting for a response")
-                raise
             except OSError as e:
+                # Here we catch IOError (alias) and WinError (subclass) as well
                 if self._closed:
                     raise RuntimeError(
                         "client closed while waiting for a response with OSError exception"

--- a/python/tk_desktop/rpc.py
+++ b/python/tk_desktop/rpc.py
@@ -17,6 +17,7 @@ import threading
 import time
 import traceback
 import multiprocessing.connection
+from  multiprocessing.context import AuthenticationError
 
 # We have to import Python's pickle to serialize our data.
 # tk-core's sgtk.util.pickle module assumes too much about the data
@@ -369,7 +370,7 @@ class RPCServerThread(threading.Thread):
                         logger.debug("   traceback:\n%s" % traceback.format_exc())
                         if respond:
                             connection.send(pickle.dumps(e))
-            except (EOFError, IOError):
+            except (EOFError, IOError, AuthenticationError) as e:
                 # let these errors go
                 # just keep serving new connections
                 pass

--- a/python/tk_desktop/rpc.py
+++ b/python/tk_desktop/rpc.py
@@ -470,10 +470,10 @@ class RPCProxy(object):
                     raise RuntimeError("client closed while waiting for a response")
 
                 # Check if there's a WinError that causes flaky behavior on CI
-                if sys.platform == 'win32':
+                if sys.platform == "win32":
                     import _winapi
 
-                    if e.winerror == _winapi.ERROR_NO_DATA:
+                    if e.winerror:
                         raise RuntimeError("client closed while waiting for a response")
                 raise
 

--- a/python/tk_desktop/rpc.py
+++ b/python/tk_desktop/rpc.py
@@ -8,6 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import errno
 import os
 import sys
 import uuid
@@ -272,9 +273,9 @@ class RPCServerThread(threading.Thread):
                     )
                     ready = True
                 except AttributeError as e:
-                    # The server has been closed. `_listener` is None.
                     logger.debug("Error during select:", exc_info=True)
                     if self.server._listener:
+                        # The server has been closed. `_listener` is None.
                         raise
                     ready = False
                 except WindowsError as e:
@@ -299,8 +300,6 @@ class RPCServerThread(threading.Thread):
                         raise
                     ready = False
                 except select.error as e:
-                    import errno
-
                     logger.debug("Error during select:", exc_info=True)
                     if e.args[0] != errno.EBADF:
                         raise

--- a/python/tk_desktop/rpc.py
+++ b/python/tk_desktop/rpc.py
@@ -370,7 +370,7 @@ class RPCServerThread(threading.Thread):
                         logger.debug("   traceback:\n%s" % traceback.format_exc())
                         if respond:
                             connection.send(pickle.dumps(e))
-            except (EOFError, IOError, AuthenticationError) as e:
+            except (EOFError, IOError, AuthenticationError):
                 # let these errors go
                 # just keep serving new connections
                 pass

--- a/python/tk_desktop/rpc.py
+++ b/python/tk_desktop/rpc.py
@@ -270,6 +270,12 @@ class RPCServerThread(threading.Thread):
                         self.server.address, self.LISTEN_TIMEOUT * 1000
                     )
                     ready = True
+                except AttributeError as e:
+                    # The server has been closed.
+                    logger.debug("Error during select:", exc_info=True)
+                    if self.server._listener:
+                        raise
+                    ready = False
                 except WindowsError as e:
                     logger.debug("Error during WaitNamedPipe:", exc_info=True)
                     if e.args[0] not in (
@@ -288,6 +294,8 @@ class RPCServerThread(threading.Thread):
                 except AttributeError as e:
                     # The server has been closed.
                     logger.debug("Error during select:", exc_info=True)
+                    if self.server._listener:
+                        raise
                     ready = False
                 except select.error as e:
                     import errno

--- a/python/tk_desktop/rpc.py
+++ b/python/tk_desktop/rpc.py
@@ -468,7 +468,7 @@ class RPCProxy(object):
                 # Here we catch IOError (alias) and WinError (subclass) as well
                 if self._closed:
                     raise RuntimeError(
-                        "client closed while waiting for a response with OSError exception"
+                        "client closed while waiting for a response"
                     )
                 raise
 

--- a/python/tk_desktop/rpc.py
+++ b/python/tk_desktop/rpc.py
@@ -465,11 +465,16 @@ class RPCProxy(object):
                         raise RuntimeError("client closed while waiting for a response")
                     continue
             except OSError as e:
-                # Here we catch IOError (alias) and WinError (subclass) as well
+                # IOError it's an alias of OSError
                 if self._closed:
-                    raise RuntimeError(
-                        "client closed while waiting for a response"
-                    )
+                    raise RuntimeError("client closed while waiting for a response")
+
+                # Check if there's a WinError that causes flaky behavior on CI
+                if sys.platform == 'win32':
+                    import _winapi
+
+                    if e.winerror == _winapi.ERROR_NO_DATA:
+                        raise RuntimeError("client closed while waiting for a response")
                 raise
 
         # read the result


### PR DESCRIPTION
Increase the existing error handling to have more use cases. This will prevent flaky tests on CI.