### PR TITLE
SG-3081 - Add High-DPI support to the FPTR desktop app

### DIFF
--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -311,7 +311,7 @@ class DesktopEngineProjectImplementation(object):
             return 0
 
     def _initialize_application(self):
-        from tank.platform.qt import QtGui
+        from tank.platform.qt import QtGui, QtCore
 
         if sgtk.util.is_macos():
             # If we are on Mac with PySide2, then starting a QApplication even with no Windows
@@ -330,8 +330,12 @@ class DesktopEngineProjectImplementation(object):
         # If qt is already running and a QApplication has been
         # initialized (e.g. on the engine_init core hook)
         # let's create a Qt app instance.
+
         app = QtGui.QApplication.instance()
         if not app:
+            if QtCore.qVersion()[0] == "5":
+                QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+
             # if it does not exist then a QApplication is created
             app = QtGui.QApplication([])
 

--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -311,7 +311,7 @@ class DesktopEngineProjectImplementation(object):
             return 0
 
     def _initialize_application(self):
-        from tank.platform.qt import QtGui, QtCore
+        from tank.platform.qt import QtCore, QtGui
 
         if sgtk.util.is_macos():
             # If we are on Mac with PySide2, then starting a QApplication even with no Windows

--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -330,11 +330,22 @@ class DesktopEngineProjectImplementation(object):
         # If qt is already running and a QApplication has been
         # initialized (e.g. on the engine_init core hook)
         # let's create a Qt app instance.
-
         app = QtGui.QApplication.instance()
         if not app:
             if QtCore.qVersion()[0] == "5":
-                QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+                # Enable High DPI support in Qt5 (default enabled in Qt6)
+                #
+                # Only enable it if none of the Qt environment variables related to
+                # High-DPI are set
+
+                if "QT_AUTO_SCREEN_SCALE_FACTOR" in os.environ:
+                    pass
+                elif "QT_SCALE_FACTOR" in os.environ:
+                    pass
+                elif "QT_SCREEN_SCALE_FACTORS" in os.environ:
+                    pass
+                else:
+                    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
             # if it does not exist then a QApplication is created
             app = QtGui.QApplication([])

--- a/python/tk_desktop/desktop_engine_project_implementation.py
+++ b/python/tk_desktop/desktop_engine_project_implementation.py
@@ -345,7 +345,9 @@ class DesktopEngineProjectImplementation(object):
                 elif "QT_SCREEN_SCALE_FACTORS" in os.environ:
                     pass
                 else:
-                    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+                    QtCore.QCoreApplication.setAttribute(
+                        QtCore.Qt.AA_EnableHighDpiScaling
+                    )
 
             # if it does not exist then a QApplication is created
             app = QtGui.QApplication([])

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -374,7 +374,19 @@ class DesktopEngineSiteImplementation(object):
         app = QtGui.QApplication.instance()
         if app is None:
             if QtCore.qVersion()[0] == "5":
-                QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+                # Enable High DPI support in Qt5 (default enabled in Qt6)
+                #
+                # Only enable it if none of the Qt environment variables related to
+                # High-DPI are set
+
+                if "QT_AUTO_SCREEN_SCALE_FACTOR" in os.environ:
+                    pass
+                elif "QT_SCALE_FACTOR" in os.environ:
+                    pass
+                elif "QT_SCREEN_SCALE_FACTORS" in os.environ:
+                    pass
+                else:
+                    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
             app = QtGui.QApplication(sys.argv)
 

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -386,7 +386,9 @@ class DesktopEngineSiteImplementation(object):
                 elif "QT_SCREEN_SCALE_FACTORS" in os.environ:
                     pass
                 else:
-                    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+                    QtCore.QCoreApplication.setAttribute(
+                        QtCore.Qt.AA_EnableHighDpiScaling
+                    )
 
             app = QtGui.QApplication(sys.argv)
 

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -369,10 +369,13 @@ class DesktopEngineSiteImplementation(object):
         :param startup_descriptor: Descriptor of the Desktop Startup code. Can be omitted.
         """
         # Initialize Qt app
-        from tank.platform.qt import QtGui
+        from tank.platform.qt import QtCore, QtGui
 
         app = QtGui.QApplication.instance()
         if app is None:
+            if QtCore.qVersion()[0] == "5":
+                QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+
             app = QtGui.QApplication(sys.argv)
 
         # update the app icon

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -334,7 +334,19 @@ def start_app(engine):
         from tank.platform.qt import QtCore, QtGui
 
         if QtCore.qVersion()[0] == "5":
-            QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+            # Enable High DPI support in Qt5 (default enabled in Qt6)
+            #
+            # Only enable it if none of the Qt environment variables related to
+            # High-DPI are set
+
+            if "QT_AUTO_SCREEN_SCALE_FACTOR" in os.environ:
+                pass
+            elif "QT_SCALE_FACTOR" in os.environ:
+                pass
+            elif "QT_SCREEN_SCALE_FACTORS" in os.environ:
+                pass
+            else:
+                QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
         app = QtGui.QApplication([])
         app.setQuitOnLastWindowClosed(False)

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -331,7 +331,10 @@ def start_app(engine):
         # NOTE
         # The following code is meant to run for very old verions of tk-desktop. It
         # should not be edited to support newer features.
-        from tank.platform.qt import QtGui
+        from tank.platform.qt import QtCore, QtGui
+
+        if QtCore.qVersion()[0] == "5":
+            QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
         app = QtGui.QApplication([])
         app.setQuitOnLastWindowClosed(False)


### PR DESCRIPTION
Enable the `AA_EnableHighDpiScaling` property before instantiating the _QApplication_.

Relates to:

- shotgunsoftware/tk-shell#32
- shotgunsoftware/tk-framework-desktopstartup#126
- shotgunsoftware/tk-shotgun#19
