### PR TITLE
SG-36162 Refactor __launch_app_proxy_for_project in a QThread

### DIFF
--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -507,7 +507,7 @@ class DesktopEngineSiteImplementation(object):
             splash.hide()
 
         # initialize System Tray
-        self.desktop_window = desktop_window.DesktopWindow(console, self._task_manager)
+        self.desktop_window = desktop_window.DesktopWindow(console)
 
         # We need for the dialog to exist for messages to get to the UI console.
         if kwargs.get("server") is not None:

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -507,7 +507,7 @@ class DesktopEngineSiteImplementation(object):
             splash.hide()
 
         # initialize System Tray
-        self.desktop_window = desktop_window.DesktopWindow(console)
+        self.desktop_window = desktop_window.DesktopWindow(console, self._task_manager)
 
         # We need for the dialog to exist for messages to get to the UI console.
         if kwargs.get("server") is not None:

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1362,7 +1362,9 @@ class DesktopWindow(SystrayWindow):
             self.requested_pipeline_configuration_id = requested_pipeline_configuration_id
 
             self.project_overlay.start_progress()
-            # trigger an update to the model to track this project access
+            # Trigger an update to the model to track this project access
+            # this is done in a separate thread to avoid blocking the UI.
+            # After it finishes, we start phases 2 and 3 in __get_pipeline_configurations method
             self.set_just_accessed_thread = StartAppProxyForProject(self.__set_project_just_accessed, project)
             self.set_just_accessed_thread.finished.connect(self.__get_pipeline_configurations)
             self.set_just_accessed_thread.start()
@@ -1773,6 +1775,9 @@ class DesktopWindow(SystrayWindow):
 
 
 class StartAppProxyForProject(QtCore.QThread):
+    """
+    Thread to set the accessed time for a project.
+    """
     def __init__(self, fn, project):
         super().__init__()
         self.project = project

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -280,7 +280,7 @@ class DesktopWindow(SystrayWindow):
 
         # Initially hide the Advanced project setup... menu item. This
         # menu item will only be displayed for projects that do not have
-        # any pipeline configurations registered in Shotgun.
+        # any pipeline configurations registered in FPTR.
         self.ui.actionAdvanced_Project_Setup.setVisible(False)
 
         name_action.triggered.connect(self.open_site_in_browser)
@@ -1366,8 +1366,6 @@ class DesktopWindow(SystrayWindow):
             self.set_just_accessed_thread = StartAppProxyForProject(self.__set_project_just_accessed, project)
             self.set_just_accessed_thread.finished.connect(self.__get_pipeline_configurations)
             self.set_just_accessed_thread.start()
-            # self.__set_project_just_accessed(project)
-            # QtGui.QApplication.instance().processEvents()
         except Exception as error:
             log.exception(str(error))
             message = (
@@ -1443,7 +1441,7 @@ class DesktopWindow(SystrayWindow):
             if not any(
                 True if pc["project"] else False for pc in pipeline_configurations
             ):
-                # If we have the new Shotgun that supports zero config, add the setup project entry in the menu
+                # If we have the new FPTR that supports zero config, add the setup project entry in the menu
                 if self.__get_server_version(engine.shotgun) >= (7, 2, 0):
                     self.ui.actionAdvanced_Project_Setup.setVisible(True)
                 else:
@@ -1480,7 +1478,7 @@ class DesktopWindow(SystrayWindow):
                 config_descriptor = pipeline_configuration_to_load["descriptor"]
 
                 # The config descriptor can be None if the pipeline configuration hasn't been
-                # configured properly in Shotgun.
+                # configured properly in FPTR.
                 if not config_descriptor:
                     raise Exception(
                         "The pipeline configuration '{name}' (id: {id}) has not been properly "
@@ -1499,7 +1497,6 @@ class DesktopWindow(SystrayWindow):
             return
 
         # From this point on, we don't touch the UI anymore.
-        # self.project_overlay.start_progress()
 
         if config_descriptor.exists_local():
             self._start_bg_process(config_descriptor, toolkit_manager)

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1716,16 +1716,16 @@ class DesktopWindow(SystrayWindow):
         new_page.raise_()
 
         anim_old = QtCore.QPropertyAnimation(current_page, b"pos", self)
-        anim_old.setDuration(500)
+        anim_old.setDuration(250)
         anim_old.setStartValue(QtCore.QPoint(curr_pos.x(), curr_pos.y()))
         anim_old.setEndValue(QtCore.QPoint(curr_pos.x() - offsetx, curr_pos.y()))
-        anim_old.setEasingCurve(QtCore.QEasingCurve.OutBack)
+        anim_old.setEasingCurve(QtCore.QEasingCurve.OutQuart)
 
         anim_new = QtCore.QPropertyAnimation(new_page, b"pos", self)
-        anim_new.setDuration(500)
+        anim_new.setDuration(250)
         anim_new.setStartValue(QtCore.QPoint(curr_pos.x() + offsetx, curr_pos.y()))
         anim_new.setEndValue(QtCore.QPoint(curr_pos.x(), curr_pos.y()))
-        anim_new.setEasingCurve(QtCore.QEasingCurve.OutBack)
+        anim_new.setEasingCurve(QtCore.QEasingCurve.OutQuart)
 
         anim_group = QtCore.QParallelAnimationGroup(self)
         anim_group.addAnimation(anim_old)

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1359,14 +1359,20 @@ class DesktopWindow(SystrayWindow):
             self.ui.actionRefresh_Projects.setVisible(False)
 
             self.current_project = project
-            self.requested_pipeline_configuration_id = requested_pipeline_configuration_id
+            self.requested_pipeline_configuration_id = (
+                requested_pipeline_configuration_id
+            )
 
             self.project_overlay.start_progress()
             # Trigger an update to the model to track this project access
             # this is done in a separate thread to avoid blocking the UI.
             # After it finishes, we start phases 2 and 3 in __get_pipeline_configurations method
-            self.set_just_accessed_thread = StartAppProxyForProject(self.__set_project_just_accessed, project)
-            self.set_just_accessed_thread.finished.connect(self.__get_pipeline_configurations)
+            self.set_just_accessed_thread = StartAppProxyForProject(
+                self.__set_project_just_accessed, project
+            )
+            self.set_just_accessed_thread.finished.connect(
+                self.__get_pipeline_configurations
+            )
             self.set_just_accessed_thread.start()
         except Exception as error:
             log.exception(str(error))
@@ -1778,6 +1784,7 @@ class StartAppProxyForProject(QtCore.QThread):
     """
     Thread to set the accessed time for a project.
     """
+
     def __init__(self, fn, project):
         super().__init__()
         self.project = project

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -232,7 +232,6 @@ class DesktopWindow(SystrayWindow):
         # Setup the console
         self.__console = console
 
-
         # User menu
         ###########################
         user = engine.get_current_login()
@@ -1386,8 +1385,12 @@ class DesktopWindow(SystrayWindow):
         # Trigger an update to the model to track this project access
         # this is done in a separate thread to avoid blocking the UI.
         # After it finishes, we start phases 2 and 3 in __launch_app_proxy_for_project_follow_up
-        self._set_just_accessed_thread = GenericFunctionWrapperQThread(self, self.__set_project_just_accessed, {"project": project})
-        self._set_just_accessed_thread.finished.connect(self.__load_pipeline_configuration)
+        self._set_just_accessed_thread = GenericFunctionWrapperQThread(
+            self, self.__set_project_just_accessed, {"project": project}
+        )
+        self._set_just_accessed_thread.finished.connect(
+            self.__load_pipeline_configuration
+        )
         self._set_just_accessed_thread.start()
 
     def __load_pipeline_configuration(self):
@@ -1617,9 +1620,9 @@ class DesktopWindow(SystrayWindow):
             self._push_dll_state()
 
             try:
-                os.environ[
-                    "SHOTGUN_DESKTOP_CURRENT_USER"
-                ] = sgtk.authentication.serialize_user(engine.get_current_user())
+                os.environ["SHOTGUN_DESKTOP_CURRENT_USER"] = (
+                    sgtk.authentication.serialize_user(engine.get_current_user())
+                )
                 engine.execute_hook(
                     "hook_launch_python",
                     project_python=path_to_python,
@@ -1771,9 +1774,9 @@ class DesktopWindow(SystrayWindow):
             # Certain versions of core don't like configuration's without an
             # info.yml, so tolerate it.
             try:
-                versions[
-                    engine.sgtk.configuration_descriptor.display_name
-                ] = engine.sgtk.configuration_descriptor.version
+                versions[engine.sgtk.configuration_descriptor.display_name] = (
+                    engine.sgtk.configuration_descriptor.version
+                )
             except Exception:
                 pass
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -800,6 +800,10 @@ class DesktopWindow(SystrayWindow):
         # disconnect from the current project
         engine.site_comm.shut_down()
 
+        # disconnect task manager
+        self._bg_task_manager.task_completed.disconnect(self._on_task_completed)
+        self._bg_task_manager.task_failed.disconnect(self._on_task_failed)
+
         self._save_setting("pos", self.pos(), site_specific=True)
 
         self.close()
@@ -1371,9 +1375,7 @@ class DesktopWindow(SystrayWindow):
         self.ui.actionRefresh_Projects.setVisible(False)
 
         self.current_project = project
-        self.requested_pipeline_configuration_id = (
-            requested_pipeline_configuration_id
-        )
+        self.requested_pipeline_configuration_id = requested_pipeline_configuration_id
 
         self.project_overlay.start_progress()
         # Trigger an update to the model to track this project access

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1614,9 +1614,9 @@ class DesktopWindow(SystrayWindow):
             self._push_dll_state()
 
             try:
-                os.environ["SHOTGUN_DESKTOP_CURRENT_USER"] = (
-                    sgtk.authentication.serialize_user(engine.get_current_user())
-                )
+                os.environ[
+                    "SHOTGUN_DESKTOP_CURRENT_USER"
+                ] = sgtk.authentication.serialize_user(engine.get_current_user())
                 engine.execute_hook(
                     "hook_launch_python",
                     project_python=path_to_python,
@@ -1768,9 +1768,9 @@ class DesktopWindow(SystrayWindow):
             # Certain versions of core don't like configuration's without an
             # info.yml, so tolerate it.
             try:
-                versions[engine.sgtk.configuration_descriptor.display_name] = (
-                    engine.sgtk.configuration_descriptor.version
-                )
+                versions[
+                    engine.sgtk.configuration_descriptor.display_name
+                ] = engine.sgtk.configuration_descriptor.version
             except Exception:
                 pass
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1192,13 +1192,11 @@ class DesktopWindow(SystrayWindow):
         try:
             self._project_model.update_project_accessed_time(project)
         except Exception as error:
-            log.exception(str(error))
             message = (
-                "%s"
-                "\n\nThere was an error connecting to Flow Production Tracking."
-                "\n\nFor more details, see the console." % str(error)
+                "There was an error connecting to Flow Production Tracking:\n\n"
+                f"{error}"
             )
-            self.project_overlay.show_error_message(message)
+            log.exception(message)
 
     def _on_project_selection(self, selected, deselected):
         selected_indexes = selected.indexes()


### PR DESCRIPTION
Move the logic for phase 1 (update last accessed timestamp in SG)  when launching of the app proxy for a project in a `QThread` ~~[Background Task Manager](https://developers.shotgridsoftware.com/tk-framework-shotgunutils/task_manager.html)~~ so it doesn't block the UI.