### PR TITLE
SG-38672 Removed dead authentication code

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -930,11 +930,8 @@ class DesktopWindow(SystrayWindow):
         """
         Logs current user out.
         """
-        engine = sgtk.platform.current_engine()
         try:
             sg_auth.ShotgunAuthenticator().clear_default_user()
-            if engine.uses_legacy_authentication():
-                engine.create_legacy_login_instance().logout()
             return True
         except Exception:
             # if logout raises an exception, just log and don't crash
@@ -948,17 +945,6 @@ class DesktopWindow(SystrayWindow):
         :param str new_host: URL of the new host.
         :param str new_user: Login of the new user.
         """
-
-        engine = sgtk.platform.current_engine()
-
-        # This is for ye-olde PTR desktop app < 1.1
-        if engine.uses_legacy_authentication():
-            login_framework = engine.create_legacy_login_instance()
-            if new_host:
-                login_framework.set_default_host(new_host)
-            if new_user:
-                login_framework.set_default_login(new_user)
-
         dm = sg_auth.DefaultsManager()
         if new_host:
             dm.set_host(new_host)

--- a/tests/test_command_panel.py
+++ b/tests/test_command_panel.py
@@ -11,7 +11,7 @@
 import pytest
 import itertools
 import datetime
-from mock import Mock
+from unittest.mock import Mock
 import sys, os
 import pkgutil
 


### PR DESCRIPTION
### **Description**
This PR removes dead code related to uses_legacy_authentication.

This cleanup follows a previously identified issue where LooseVersion("v1.9.1") was parsed as ["v1", 9, 1], which is described in more detail in that earlier [PR](https://github.com/shotgunsoftware/tk-desktop/pull/194).

Rather than removing the unused code at the time, we opted to fix the issue by updating the version string to avoid the problematic comparison. This PR now completes the process by removing the obsolete logic that was originally tied to that condition.

### **Test**
![image](https://github.com/user-attachments/assets/804e0fe0-1e68-410e-ad86-b3bdc84c5b97)

