### PR TITLE
SG-38064 Inconsistent comparison - bug fix

### DIFF
--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -520,9 +520,9 @@ class DesktopEngineSiteImplementation(object):
         Returns if the PTR desktop app installed code uses the tk-framework-login for
         logging in.
 
-        :returns: True the bootstrap logic is older than 1.1.0, False otherwise.
+        :returns: True the bootstrap logic is older than v1.1.0, False otherwise.
         """
-        return LooseVersion(self.app_version) < LooseVersion("1.1.0")
+        return LooseVersion(self.app_version) < LooseVersion("v1.1.0")
 
     def create_legacy_login_instance(self):
         """

--- a/tests/test_command_panel.py
+++ b/tests/test_command_panel.py
@@ -11,7 +11,7 @@
 import pytest
 import itertools
 import datetime
-from mock import Mock
+from unittest.mock import Mock
 import sys, os
 import pkgutil
 


### PR DESCRIPTION
### **Description**
- The error happens because LooseVersion("v1.9.1") is parsed as ["v1", 9, 1], while LooseVersion("1.1.0") is ["1", 1, 0]. The comparison fails when Python tries to compare "v1" (a string) with 1 (an integer). Adding the "v" prefix would make them comparable.
![image](https://github.com/user-attachments/assets/7d0e7a51-1186-4b3e-939e-9cf277bfe1fb)

### **Test**
- With the fix, Desktop launches without any issues.
![image](https://github.com/user-attachments/assets/9c91ea5a-09b0-4069-afbe-c543b1e6fa6a)
