### PR TITLE
SG-37924 Replace utcnow() for Python 3.12

### DIFF
--- a/python/tk_desktop/command_panel/command_panel.py
+++ b/python/tk_desktop/command_panel/command_panel.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from datetime import datetime
+from datetime import datetime, timezone
 from sgtk.platform.qt import QtGui, QtCore
 
 from .shared import MAX_RECENTS
@@ -185,7 +185,7 @@ class CommandPanel(QtGui.QWidget):
             return
 
         command_name = str(command_name)
-        self._recents[command_name] = {"timestamp": datetime.utcnow()}
+        self._recents[command_name] = {"timestamp": datetime.now(timezone.utc)}
         self._store_recents()
         self._refresh_recent_list(command_name)
         self._restrict_recent_buttons(self._get_optimal_width())

--- a/python/tk_desktop/project_model.py
+++ b/python/tk_desktop/project_model.py
@@ -321,7 +321,7 @@ class SgProjectModel(ShotgunModel):
         # Update the data in the model
         item = self.item_from_entity("Project", project["id"])
         # set to unix seconds rather than datetime to be compatible with Shotgun model
-        utc_now_epoch = time.mktime(datetime.datetime.utcnow().utctimetuple())
+        utc_now_epoch = time.mktime(datetime.datetime.now(datetime.timezone.utc).utctimetuple())
         project["last_accessed_by_current_user"] = utc_now_epoch
         item.setData(project, ShotgunModel.SG_DATA_ROLE)
 

--- a/python/tk_desktop/project_model.py
+++ b/python/tk_desktop/project_model.py
@@ -321,7 +321,9 @@ class SgProjectModel(ShotgunModel):
         # Update the data in the model
         item = self.item_from_entity("Project", project["id"])
         # set to unix seconds rather than datetime to be compatible with Shotgun model
-        utc_now_epoch = time.mktime(datetime.datetime.now(datetime.timezone.utc).utctimetuple())
+        utc_now_epoch = time.mktime(
+            datetime.datetime.now(datetime.timezone.utc).utctimetuple()
+        )
         project["last_accessed_by_current_user"] = utc_now_epoch
         item.setData(project, ShotgunModel.SG_DATA_ROLE)
 

--- a/tests/test_command_panel.py
+++ b/tests/test_command_panel.py
@@ -84,7 +84,7 @@ def test_sections_sorted(show_recents, commands):
     view = CommandPanel(
         sgtk.platform.qt.QtGui.QScrollArea(),
         Settings(
-            {PROJECT_KEY: {"command 0": {"timestamp": datetime.datetime.utcnow()}}}
+            {PROJECT_KEY: {"command 0": {"timestamp": datetime.datetime.now(datetime.timezone.utc)}}}
         ),
     )
     view.configure(PROJECT, groups, show_recents=show_recents)
@@ -126,7 +126,7 @@ def test_clear_deletes_all_but_stretcher():
     view = CommandPanel(
         sgtk.platform.qt.QtGui.QScrollArea(),
         Settings(
-            {PROJECT_KEY: {"maya_2020": {"timestamp": datetime.datetime.utcnow()}}}
+            {PROJECT_KEY: {"maya_2020": {"timestamp": datetime.datetime.now(datetime.timezone.utc)}}}
         ),
     )
     view.configure(PROJECT, ["Creative Tools", "Editorial"], show_recents=True)

--- a/tests/test_command_panel.py
+++ b/tests/test_command_panel.py
@@ -84,7 +84,13 @@ def test_sections_sorted(show_recents, commands):
     view = CommandPanel(
         sgtk.platform.qt.QtGui.QScrollArea(),
         Settings(
-            {PROJECT_KEY: {"command 0": {"timestamp": datetime.datetime.now(datetime.timezone.utc)}}}
+            {
+                PROJECT_KEY: {
+                    "command 0": {
+                        "timestamp": datetime.datetime.now(datetime.timezone.utc)
+                    }
+                }
+            }
         ),
     )
     view.configure(PROJECT, groups, show_recents=show_recents)
@@ -126,7 +132,13 @@ def test_clear_deletes_all_but_stretcher():
     view = CommandPanel(
         sgtk.platform.qt.QtGui.QScrollArea(),
         Settings(
-            {PROJECT_KEY: {"maya_2020": {"timestamp": datetime.datetime.now(datetime.timezone.utc)}}}
+            {
+                PROJECT_KEY: {
+                    "maya_2020": {
+                        "timestamp": datetime.datetime.now(datetime.timezone.utc)
+                    }
+                }
+            }
         ),
     )
     view.configure(PROJECT, ["Creative Tools", "Editorial"], show_recents=True)


### PR DESCRIPTION
This pull request updates the handling of timestamps throughout the codebase to use timezone-aware `datetime` objects, ensuring consistency and preventing potential issues with naive `datetime` usage. The changes also include updates to corresponding test cases.

### Updates to timestamp handling:

* [`python/tk_desktop/command_panel/command_panel.py`](diffhunk://#diff-6d80519da321fc7bd0de525e8cb94e8efe7bec998484024da4e64518b40df332L188-R188): Modified the `_update_recents_list` method to use `datetime.now(timezone.utc)` instead of `datetime.utcnow()` for creating timezone-aware timestamps.
* [`python/tk_desktop/project_model.py`](diffhunk://#diff-6cf3b0c8c33231d62e9107b7f2b39f02af810280b50acbbe241bc2b4ef95fb3bL324-R324): Updated the `update_project_accessed_time` method to use `datetime.now(datetime.timezone.utc)` for compatibility with timezone-aware timestamps.

### Updates to test cases:

* [`tests/test_command_panel.py`](diffhunk://#diff-0ed04129f976a708efc4f72d12d5552738fbd0e37c9773d52ce843459b434b15L87-R87): Updated the `test_sections_sorted` and `test_clear_deletes_all_but_stretcher` test cases to use `datetime.now(datetime.timezone.utc)` for consistency with the main code changes. [[1]](diffhunk://#diff-0ed04129f976a708efc4f72d12d5552738fbd0e37c9773d52ce843459b434b15L87-R87) [[2]](diffhunk://#diff-0ed04129f976a708efc4f72d12d5552738fbd0e37c9773d52ce843459b434b15L129-R129)

### Import adjustments:

* [`python/tk_desktop/command_panel/command_panel.py`](diffhunk://#diff-6d80519da321fc7bd0de525e8cb94e8efe7bec998484024da4e64518b40df332L11-R11): Added `timezone` to the `datetime` import to support the changes.