### PR TITLE
SG-15664 Replace `imp`

### DIFF
--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -82,7 +82,7 @@ def _create_proxy(data):
     # Connect to the main desktop process so we can send updates to it.
     # We're not guaranteed if the py or pyc file will be passed back to us
     # from the desktop due to write permissions on the folder.
-    
+
     spec = importlib.util.spec_from_file_location("rpc", data["rpc_lib_path"])
     if spec is None or spec.loader is None:
         raise ImportError(

--- a/python/utils/bootstrap_utilities.py
+++ b/python/utils/bootstrap_utilities.py
@@ -21,10 +21,9 @@ engine is bootstrapped and finalized.
 import os
 import sys
 import traceback
-import imp
+import importlib.util
 import logging
 import inspect
-import pprint
 
 
 class ProxyLoggingHandler(logging.Handler):
@@ -81,9 +80,16 @@ def _create_proxy(data):
     :returns: A connection back to the PTR desktop app.
     """
     # Connect to the main desktop process so we can send updates to it.
-    # We're not guanranteed if the py or pyc file will be passed back to us
+    # We're not guaranteed if the py or pyc file will be passed back to us
     # from the desktop due to write permissions on the folder.
-    rpc_lib = imp.load_source("rpc", data["rpc_lib_path"])
+    
+    spec = importlib.util.spec_from_file_location("rpc", data["rpc_lib_path"])
+    if spec is None or spec.loader is None:
+        raise ImportError(
+            "Failed to load the rpc module from {}".format(data["rpc_lib_path"])
+        )
+    rpc_lib = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(rpc_lib)
     return rpc_lib.RPCProxy(
         data["proxy_data"]["proxy_pipe"], data["proxy_data"]["proxy_auth"]
     )


### PR DESCRIPTION
This pull request refactors the module loading logic in `python/utils/bootstrap_utilities.py` to replace the deprecated `imp` module with the modern `importlib.util`. Additionally, it fixes a typo in a comment for better clarity.