### PR TITLE
SG-39630 Make sure our datetime objects are created in naive mode

### DIFF
--- a/python/tk_desktop/command_panel/command_panel.py
+++ b/python/tk_desktop/command_panel/command_panel.py
@@ -185,7 +185,7 @@ class CommandPanel(QtGui.QWidget):
             return
 
         command_name = str(command_name)
-        self._recents[command_name] = {"timestamp": datetime.now(timezone.utc)}
+        self._recents[command_name] = {"timestamp": datetime.now()}
         self._store_recents()
         self._refresh_recent_list(command_name)
         self._restrict_recent_buttons(self._get_optimal_width())

--- a/tests/test_command_panel.py
+++ b/tests/test_command_panel.py
@@ -87,7 +87,7 @@ def test_sections_sorted(show_recents, commands):
             {
                 PROJECT_KEY: {
                     "command 0": {
-                        "timestamp": datetime.datetime.now(datetime.timezone.utc)
+                        "timestamp": datetime.datetime.now()
                     }
                 }
             }
@@ -135,7 +135,7 @@ def test_clear_deletes_all_but_stretcher():
             {
                 PROJECT_KEY: {
                     "maya_2020": {
-                        "timestamp": datetime.datetime.now(datetime.timezone.utc)
+                        "timestamp": datetime.datetime.now()
                     }
                 }
             }


### PR DESCRIPTION
Critical since the info is then cached on disk in a string format that does not include the timezone so, once they are loaded back from disk, we have naive datetime  object.

Fixup regression introduced in #197:

  TypeError: can't compare offset-naive and offset-aware datetimes