### PR TITLE
SG-36372 Switch `distutil.version` to `packaging.version`

### DIFF
--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -14,7 +14,6 @@ import sys
 import string
 import collections
 
-from distutils.version import LooseVersion
 import sgtk
 from tank_vendor.shotgun_authentication import ShotgunAuthenticator, DefaultsManager
 

--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -18,7 +18,6 @@ import pprint
 import inspect
 import re
 from collections import OrderedDict
-from distutils.version import LooseVersion
 
 
 from tank.platform.qt import QtCore, QtGui
@@ -1773,8 +1772,7 @@ class DesktopWindow(SystrayWindow):
 
         versions = OrderedDict()
         versions["App"] = engine.app_version
-        if engine.app_version >= LooseVersion("v1.6.0"):
-            versions["Python"] = "{}.{}.{}".format(*sys.version_info[0:3])
+        versions["Python"] = "{}.{}.{}".format(*sys.version_info[0:3])
 
         if engine.startup_version:
             versions["Startup"] = engine.startup_version


### PR DESCRIPTION
- Remove unused imports
- It's been a while since we don't support SGD v.1.6.0. We can get rid of the legacy conditional.