### PR TITLE
SG-43220 Fix Desktop About to show the selected project is config

### DIFF
--- a/python/tk_desktop/desktop_window.py
+++ b/python/tk_desktop/desktop_window.py
@@ -1920,13 +1920,14 @@ class DesktopWindow(SystrayWindow):
         versions["Engine"] = engine.version
         versions["Core"] = engine.sgtk.version
 
-        if engine.sgtk.configuration_descriptor:
-            # Certain versions of core don't like configuration's without an
-            # info.yml, so tolerate it.
+        descriptor = self._current_pipeline_descriptor or engine.sgtk.configuration_descriptor
+
+        if descriptor:
+            # Use the selected project config first.
+            # Keep the About dialog working even if info.yml metadata cannot be read.
+
             try:
-                versions[engine.sgtk.configuration_descriptor.display_name] = (
-                    engine.sgtk.configuration_descriptor.version
-                )
+                versions[descriptor.display_name] = descriptor.version
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary

Display the selected project configuration in Desktop About.

## Problem

Desktop About incorrectly displays the site configuration instead of the selected project configuration.

## Change

Use the selected project config first.
If it is not available, use the current engine config.

## Result

Desktop About shows the selected project config more clearly.



<img width="211" height="356" alt="project_config_about" src="https://github.com/user-attachments/assets/901bf223-ee57-47eb-b304-a383a7e8e73a" />
