### PR TITLE
SG-42329 Fix multiple apps in desktop list after restart

### DIFF
--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -237,9 +237,12 @@ class DesktopEngineSiteImplementation(object):
         """
         Invoked when background process has created proxy
         """
-        # Clears the project menu so the previous engine's actions
-        # are removed before adding new one
-        self.desktop_window.clear_actions_from_project_menu()
+        # Clear the full app UI before the new engine registers its commands.
+        # When the project subprocess initiates its own shutdown (e.g. "Reload and
+        # Restart"), it calls destroy_app_proxy which only closes the RPC proxy
+        # without emitting proxy_closing — so _on_proxy_closing / clear_app_uis
+        # never runs.
+        self.desktop_window.clear_app_uis()
 
     def set_groups(self, groups, show_recents=True):
         self.desktop_window.set_groups(groups, show_recents)

--- a/python/tk_desktop/desktop_engine_site_implementation.py
+++ b/python/tk_desktop/desktop_engine_site_implementation.py
@@ -240,7 +240,7 @@ class DesktopEngineSiteImplementation(object):
         # Clear the full app UI before the new engine registers its commands.
         # When the project subprocess initiates its own shutdown (e.g. "Reload and
         # Restart"), it calls destroy_app_proxy which only closes the RPC proxy
-        # without emitting proxy_closing — so _on_proxy_closing / clear_app_uis
+        # without emitting proxy_closing - so _on_proxy_closing / clear_app_uis
         # never runs.
         self.desktop_window.clear_app_uis()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@
 
 import sys
 import os
+from unittest.mock import MagicMock
 
 # Adds the python/tk_desktop folder to the python path so we can import
 # the notifications and rpc modules for testing.
@@ -22,3 +23,70 @@ tk_desktop_path = os.path.abspath(
     )
 )
 sys.path.insert(0, tk_desktop_path)
+
+# Also expose the tk_desktop package itself so tests can use
+# "from tk_desktop.X import Y" style imports.
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "python")),
+)
+
+# ── Inject lightweight sgtk / Qt stubs ────────────────────────────────────────
+# Tests that exercise tk_desktop source modules need sgtk and Qt to be
+# importable even when the full Flow Production Tracking toolkit is not
+# installed.  We inject minimal stubs into sys.modules here (conftest runs
+# before any test file is imported) so every test in the suite benefits.
+#
+# Rules:
+#  • Only inject a stub when the real package is NOT already present.
+#  • QtCore.QObject must be a real Python class so that sub-classing works
+#    (SiteCommunication inherits from it at class-definition time).
+#  • QtCore.Signal must return a callable mock so .emit() can be used.
+
+if "sgtk" not in sys.modules:
+    _log_manager = MagicMock()
+    _log_manager.get_logger.return_value = MagicMock()
+
+    _sgtk = MagicMock()
+    _sgtk.LogManager = _log_manager
+
+    # QObject must be an independent stub class, not `object` itself.
+    # Using plain `object` causes an MRO conflict because CommunicationBase
+    # also inherits from `object`:
+    #   class SiteCommunication(object, CommunicationBase) → MRO error.
+    # A dedicated stub class resolves this:
+    #   class SiteCommunication(_QObjectStub, CommunicationBase) → valid MRO.
+    class _QObjectStub:
+        """Minimal stand-in for QtCore.QObject in test environments."""
+
+    _qt_core = MagicMock()
+    _qt_core.QObject = _QObjectStub
+    _qt_core.Signal = MagicMock(side_effect=lambda *a, **kw: MagicMock())
+
+    _qt_module = MagicMock()
+    _qt_module.QtCore = _qt_core
+
+    # tank.util is imported by rpc.py as:
+    #   from tank.util import pickle as tk_pickle, is_windows
+    # The sub-module must be in sys.modules *before* the import so Python
+    # doesn't try to walk the 'tank' package (which would fail because our
+    # 'tank' stub is a MagicMock, not a real package).
+    _tank_util = MagicMock()
+    _tank_util.is_windows = MagicMock(return_value=(sys.platform == "win32"))
+
+    _stub_modules = {
+        "sgtk": _sgtk,
+        "sgtk.platform": _sgtk.platform,
+        "sgtk.platform.qt": _qt_module,
+        "sgtk.util": _sgtk.util,
+        "sgtk.bootstrap": MagicMock(),
+        "sgtk.deploy": MagicMock(),
+        "tank": _sgtk,
+        "tank.platform": _sgtk.platform,
+        "tank.platform.qt": _qt_module,
+        "tank.util": _tank_util,
+        "tank_vendor": MagicMock(),
+        "tank_vendor.shotgun_authentication": MagicMock(),
+    }
+    for _mod_name, _mod in _stub_modules.items():
+        sys.modules.setdefault(_mod_name, _mod)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@
 
 import sys
 import os
-from unittest.mock import MagicMock
 
 # Adds the python/tk_desktop folder to the python path so we can import
 # the notifications and rpc modules for testing.
@@ -23,76 +22,3 @@ tk_desktop_path = os.path.abspath(
     )
 )
 sys.path.insert(0, tk_desktop_path)
-
-# Also expose the tk_desktop package itself so tests can use
-# "from tk_desktop.X import Y" style imports.
-sys.path.insert(
-    0,
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "python")),
-)
-
-# ── Inject lightweight sgtk / Qt stubs ────────────────────────────────────────
-# Tests that exercise tk_desktop source modules need sgtk and Qt to be
-# importable even when the full Flow Production Tracking toolkit is not
-# installed.  We inject minimal stubs into sys.modules here (conftest runs
-# before any test file is imported) so every test in the suite benefits.
-#
-# Rules:
-#  • Only inject a stub when the real package is NOT already present.
-#  • QtCore.QObject must be a real Python class so that sub-classing works
-#    (SiteCommunication inherits from it at class-definition time).
-#  • QtCore.Signal must return a callable mock so .emit() can be used.
-
-try:
-    import sgtk as _sgtk_check  # noqa: F401
-    _sgtk_available = True
-except ImportError:
-    _sgtk_available = False
-
-if not _sgtk_available:
-    _log_manager = MagicMock()
-    _log_manager.get_logger.return_value = MagicMock()
-
-    _sgtk = MagicMock()
-    _sgtk.LogManager = _log_manager
-
-    # QObject must be an independent stub class, not `object` itself.
-    # Using plain `object` causes an MRO conflict because CommunicationBase
-    # also inherits from `object`:
-    #   class SiteCommunication(object, CommunicationBase) → MRO error.
-    # A dedicated stub class resolves this:
-    #   class SiteCommunication(_QObjectStub, CommunicationBase) → valid MRO.
-    class _QObjectStub:
-        """Minimal stand-in for QtCore.QObject in test environments."""
-
-    _qt_core = MagicMock()
-    _qt_core.QObject = _QObjectStub
-    _qt_core.Signal = MagicMock(side_effect=lambda *a, **kw: MagicMock())
-
-    _qt_module = MagicMock()
-    _qt_module.QtCore = _qt_core
-
-    # tank.util is imported by rpc.py as:
-    #   from tank.util import pickle as tk_pickle, is_windows
-    # The sub-module must be in sys.modules *before* the import so Python
-    # doesn't try to walk the 'tank' package (which would fail because our
-    # 'tank' stub is a MagicMock, not a real package).
-    _tank_util = MagicMock()
-    _tank_util.is_windows = MagicMock(return_value=(sys.platform == "win32"))
-
-    _stub_modules = {
-        "sgtk": _sgtk,
-        "sgtk.platform": _sgtk.platform,
-        "sgtk.platform.qt": _qt_module,
-        "sgtk.util": _sgtk.util,
-        "sgtk.bootstrap": MagicMock(),
-        "sgtk.deploy": MagicMock(),
-        "tank": _sgtk,
-        "tank.platform": _sgtk.platform,
-        "tank.platform.qt": _qt_module,
-        "tank.util": _tank_util,
-        "tank_vendor": MagicMock(),
-        "tank_vendor.shotgun_authentication": MagicMock(),
-    }
-    for _mod_name, _mod in _stub_modules.items():
-        sys.modules.setdefault(_mod_name, _mod)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,13 @@ sys.path.insert(
 #    (SiteCommunication inherits from it at class-definition time).
 #  • QtCore.Signal must return a callable mock so .emit() can be used.
 
-if "sgtk" not in sys.modules:
+try:
+    import sgtk as _sgtk_check  # noqa: F401
+    _sgtk_available = True
+except ImportError:
+    _sgtk_available = False
+
+if not _sgtk_available:
     _log_manager = MagicMock()
     _log_manager.get_logger.return_value = MagicMock()
 

--- a/tests/test_engine_user_refresh.py
+++ b/tests/test_engine_user_refresh.py
@@ -557,17 +557,3 @@ class TestProxyLifecycle:
         DesktopEngineSiteImplementation._on_proxy_closing(engine_impl)
 
         engine_impl.desktop_window.clear_app_uis.assert_called_once()
-
-    def test_subprocess_initiated_reload_clears_ui_via_proxy_created(self):
-        """
-        When reload is initiated by the subprocess (destroy_app_proxy path),
-        proxy_closing is never emitted — only proxy_created fires.  Verify that
-        clear_app_uis is still called in that scenario, covering the original
-        duplication bug.
-        """
-        engine_impl = self._make_engine_impl()
-
-        # proxy_closing does NOT fire on the subprocess-initiated reload path.
-        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
-
-        engine_impl.desktop_window.clear_app_uis.assert_called_once()

--- a/tests/test_engine_user_refresh.py
+++ b/tests/test_engine_user_refresh.py
@@ -467,107 +467,107 @@ class TestEngineUserRefreshIntegration:
         engine_impl.desktop_window.on_user_changed.assert_not_called()
 
 
-# class TestProxyLifecycle:
-#     """
-#     Tests for the proxy connection lifecycle handlers.
+class TestProxyLifecycle:
+    """
+    Tests for the proxy connection lifecycle handlers.
 
-#     Covers the "Reload and Restart" duplication bug fix: when the project
-#     subprocess initiates its own shutdown it calls destroy_app_proxy, which
-#     only closes the RPC socket without emitting proxy_closing.  As a result
-#     _on_proxy_closing / clear_app_uis never ran on that path, so the launcher
-#     retained stale buttons that were then duplicated when the new engine
-#     re-registered its commands.
+    Covers the "Reload and Restart" duplication bug fix: when the project
+    subprocess initiates its own shutdown it calls destroy_app_proxy, which
+    only closes the RPC socket without emitting proxy_closing.  As a result
+    _on_proxy_closing / clear_app_uis never ran on that path, so the launcher
+    retained stale buttons that were then duplicated when the new engine
+    re-registered its commands.
 
-#     The fix makes _on_proxy_created call clear_app_uis(), matching the
-#     behaviour of _on_proxy_closing and ensuring the panel is always wiped
-#     before new commands arrive regardless of which side initiated the shutdown.
-#     """
+    The fix makes _on_proxy_created call clear_app_uis(), matching the
+    behaviour of _on_proxy_closing and ensuring the panel is always wiped
+    before new commands arrive regardless of which side initiated the shutdown.
+    """
 
-#     def _make_engine_impl(self):
-#         engine_impl = Mock()
-#         engine_impl.desktop_window = Mock()
-#         engine_impl._collapse_rules = []
-#         return engine_impl
+    def _make_engine_impl(self):
+        engine_impl = Mock()
+        engine_impl.desktop_window = Mock()
+        engine_impl._collapse_rules = []
+        return engine_impl
 
-#     def test_on_proxy_created_clears_full_app_ui(self):
-#         """
-#         _on_proxy_created must call clear_app_uis() so the CommandPanel is
-#         wiped before the incoming engine registers its commands.
-#         """
-#         engine_impl = self._make_engine_impl()
+    def test_on_proxy_created_clears_full_app_ui(self):
+        """
+        _on_proxy_created must call clear_app_uis() so the CommandPanel is
+        wiped before the incoming engine registers its commands.
+        """
+        engine_impl = self._make_engine_impl()
 
-#         DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
 
-#         engine_impl.desktop_window.clear_app_uis.assert_called_once()
+        engine_impl.desktop_window.clear_app_uis.assert_called_once()
 
-#     def test_on_proxy_created_does_not_call_clear_actions_only(self):
-#         """
-#         The old implementation called clear_actions_from_project_menu() instead
-#         of clear_app_uis(). Verify the narrower call is no longer made directly:
-#         clear_app_uis already resets the menu via _project_menu.reset(), so a
-#         separate call to clear_actions_from_project_menu would be redundant and
-#         signals the regression has been re-introduced.
-#         """
-#         engine_impl = self._make_engine_impl()
+    def test_on_proxy_created_does_not_call_clear_actions_only(self):
+        """
+        The old implementation called clear_actions_from_project_menu() instead
+        of clear_app_uis(). Verify the narrower call is no longer made directly:
+        clear_app_uis already resets the menu via _project_menu.reset(), so a
+        separate call to clear_actions_from_project_menu would be redundant and
+        signals the regression has been re-introduced.
+        """
+        engine_impl = self._make_engine_impl()
 
-#         DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
 
-#         engine_impl.desktop_window.clear_actions_from_project_menu.assert_not_called()
+        engine_impl.desktop_window.clear_actions_from_project_menu.assert_not_called()
 
-#     def test_on_proxy_created_clears_ui_before_command_registration(self):
-#         """
-#         Simulate the reload sequence: proxy_created fires, then the new engine
-#         registers a command via trigger_register_command.  clear_app_uis must
-#         be called before add_project_command so no stale buttons survive.
-#         """
-#         engine_impl = self._make_engine_impl()
-#         call_order = []
+    def test_on_proxy_created_clears_ui_before_command_registration(self):
+        """
+        Simulate the reload sequence: proxy_created fires, then the new engine
+        registers a command via trigger_register_command.  clear_app_uis must
+        be called before add_project_command so no stale buttons survive.
+        """
+        engine_impl = self._make_engine_impl()
+        call_order = []
 
-#         engine_impl.desktop_window.clear_app_uis.side_effect = (
-#             lambda: call_order.append("clear_app_uis")
-#         )
-#         engine_impl.desktop_window.add_project_command.side_effect = (
-#             lambda *a, **kw: call_order.append("add_project_command")
-#         )
+        engine_impl.desktop_window.clear_app_uis.side_effect = (
+            lambda: call_order.append("clear_app_uis")
+        )
+        engine_impl.desktop_window.add_project_command.side_effect = (
+            lambda *a, **kw: call_order.append("add_project_command")
+        )
 
-#         DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
 
-#         with patch(
-#             "tk_desktop.desktop_engine_site_implementation.os.path.exists",
-#             return_value=False,
-#         ):
-#             DesktopEngineSiteImplementation.trigger_register_command(
-#                 engine_impl,
-#                 name="Maya 2025",
-#                 properties={"type": "default", "title": "Maya 2025"},
-#                 groups=["Studio"],
-#             )
+        with patch(
+            "tk_desktop.desktop_engine_site_implementation.os.path.exists",
+            return_value=False,
+        ):
+            DesktopEngineSiteImplementation.trigger_register_command(
+                engine_impl,
+                name="Maya 2025",
+                properties={"type": "default", "title": "Maya 2025"},
+                groups=["Studio"],
+            )
 
-#         assert call_order.index("clear_app_uis") < call_order.index(
-#             "add_project_command"
-#         ), "clear_app_uis must run before add_project_command on reload"
+        assert call_order.index("clear_app_uis") < call_order.index(
+            "add_project_command"
+        ), "clear_app_uis must run before add_project_command on reload"
 
-#     def test_on_proxy_closing_clears_full_app_ui(self):
-#         """
-#         _on_proxy_closing must still call clear_app_uis() — existing behaviour
-#         must not have been broken by the fix.
-#         """
-#         engine_impl = self._make_engine_impl()
+    def test_on_proxy_closing_clears_full_app_ui(self):
+        """
+        _on_proxy_closing must still call clear_app_uis() — existing behaviour
+        must not have been broken by the fix.
+        """
+        engine_impl = self._make_engine_impl()
 
-#         DesktopEngineSiteImplementation._on_proxy_closing(engine_impl)
+        DesktopEngineSiteImplementation._on_proxy_closing(engine_impl)
 
-#         engine_impl.desktop_window.clear_app_uis.assert_called_once()
+        engine_impl.desktop_window.clear_app_uis.assert_called_once()
 
-#     def test_subprocess_initiated_reload_clears_ui_via_proxy_created(self):
-#         """
-#         When reload is initiated by the subprocess (destroy_app_proxy path),
-#         proxy_closing is never emitted — only proxy_created fires.  Verify that
-#         clear_app_uis is still called in that scenario, covering the original
-#         duplication bug.
-#         """
-#         engine_impl = self._make_engine_impl()
+    def test_subprocess_initiated_reload_clears_ui_via_proxy_created(self):
+        """
+        When reload is initiated by the subprocess (destroy_app_proxy path),
+        proxy_closing is never emitted — only proxy_created fires.  Verify that
+        clear_app_uis is still called in that scenario, covering the original
+        duplication bug.
+        """
+        engine_impl = self._make_engine_impl()
 
-#         # proxy_closing does NOT fire on the subprocess-initiated reload path.
-#         DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+        # proxy_closing does NOT fire on the subprocess-initiated reload path.
+        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
 
-#         engine_impl.desktop_window.clear_app_uis.assert_called_once()
+        engine_impl.desktop_window.clear_app_uis.assert_called_once()

--- a/tests/test_engine_user_refresh.py
+++ b/tests/test_engine_user_refresh.py
@@ -561,7 +561,7 @@ class TestProxyLifecycle:
     def test_subprocess_initiated_reload_clears_ui_via_proxy_created(self):
         """
         When reload is initiated by the subprocess (destroy_app_proxy path),
-        proxy_closing is never emitted — only proxy_created fires.  Verify that
+        proxy_closing is never emitted — only proxy_created fires. Verify that
         clear_app_uis is still called in that scenario, covering the original
         duplication bug.
         """

--- a/tests/test_engine_user_refresh.py
+++ b/tests/test_engine_user_refresh.py
@@ -16,25 +16,12 @@ a different user re-authenticates and notifies the UI to refresh.
 """
 
 from unittest.mock import Mock, MagicMock, patch
-import sys
-import os
 
-# Ensure the tk_desktop module path is available
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
-
-# Mock sgtk.platform methods before importing tk_desktop modules
-# This prevents TankCurrentModuleNotFoundError during module import
-with patch("sgtk.platform.import_framework") as mock_import_framework, patch(
-    "sgtk.platform.get_framework"
-) as mock_get_framework:
-    # Create mock framework modules
-    mock_import_framework.return_value = MagicMock()
-    mock_get_framework.return_value = MagicMock()
-
-    # Now it's safe to import tk_desktop modules
-    from tk_desktop.desktop_engine_site_implementation import (
-        DesktopEngineSiteImplementation,
-    )
+# sgtk stubs and sys.path setup are handled by conftest.py, which runs before
+# any test module is imported.  A plain import is sufficient here.
+from tk_desktop.desktop_engine_site_implementation import (
+    DesktopEngineSiteImplementation,
+)
 
 
 class TestEngineRefreshUserCredentials:
@@ -465,3 +452,109 @@ class TestEngineUserRefreshIntegration:
 
         # Verify desktop window was NOT notified (no user change)
         engine_impl.desktop_window.on_user_changed.assert_not_called()
+
+
+class TestProxyLifecycle:
+    """
+    Tests for the proxy connection lifecycle handlers.
+
+    Covers the "Reload and Restart" duplication bug fix: when the project
+    subprocess initiates its own shutdown it calls destroy_app_proxy, which
+    only closes the RPC socket without emitting proxy_closing.  As a result
+    _on_proxy_closing / clear_app_uis never ran on that path, so the launcher
+    retained stale buttons that were then duplicated when the new engine
+    re-registered its commands.
+
+    The fix makes _on_proxy_created call clear_app_uis(), matching the
+    behaviour of _on_proxy_closing and ensuring the panel is always wiped
+    before new commands arrive regardless of which side initiated the shutdown.
+    """
+
+    def _make_engine_impl(self):
+        engine_impl = Mock()
+        engine_impl.desktop_window = Mock()
+        engine_impl._collapse_rules = []
+        return engine_impl
+
+    def test_on_proxy_created_clears_full_app_ui(self):
+        """
+        _on_proxy_created must call clear_app_uis() so the CommandPanel is
+        wiped before the incoming engine registers its commands.
+        """
+        engine_impl = self._make_engine_impl()
+
+        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+
+        engine_impl.desktop_window.clear_app_uis.assert_called_once()
+
+    def test_on_proxy_created_does_not_call_clear_actions_only(self):
+        """
+        The old implementation called clear_actions_from_project_menu() instead
+        of clear_app_uis(). Verify the narrower call is no longer made directly:
+        clear_app_uis already resets the menu via _project_menu.reset(), so a
+        separate call to clear_actions_from_project_menu would be redundant and
+        signals the regression has been re-introduced.
+        """
+        engine_impl = self._make_engine_impl()
+
+        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+
+        engine_impl.desktop_window.clear_actions_from_project_menu.assert_not_called()
+
+    def test_on_proxy_created_clears_ui_before_command_registration(self):
+        """
+        Simulate the reload sequence: proxy_created fires, then the new engine
+        registers a command via trigger_register_command.  clear_app_uis must
+        be called before add_project_command so no stale buttons survive.
+        """
+        engine_impl = self._make_engine_impl()
+        call_order = []
+
+        engine_impl.desktop_window.clear_app_uis.side_effect = (
+            lambda: call_order.append("clear_app_uis")
+        )
+        engine_impl.desktop_window.add_project_command.side_effect = (
+            lambda *a, **kw: call_order.append("add_project_command")
+        )
+
+        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+
+        with patch(
+            "tk_desktop.desktop_engine_site_implementation.os.path.exists",
+            return_value=False,
+        ):
+            DesktopEngineSiteImplementation.trigger_register_command(
+                engine_impl,
+                name="Maya 2025",
+                properties={"type": "default", "title": "Maya 2025"},
+                groups=["Studio"],
+            )
+
+        assert call_order.index("clear_app_uis") < call_order.index(
+            "add_project_command"
+        ), "clear_app_uis must run before add_project_command on reload"
+
+    def test_on_proxy_closing_clears_full_app_ui(self):
+        """
+        _on_proxy_closing must still call clear_app_uis() — existing behaviour
+        must not have been broken by the fix.
+        """
+        engine_impl = self._make_engine_impl()
+
+        DesktopEngineSiteImplementation._on_proxy_closing(engine_impl)
+
+        engine_impl.desktop_window.clear_app_uis.assert_called_once()
+
+    def test_subprocess_initiated_reload_clears_ui_via_proxy_created(self):
+        """
+        When reload is initiated by the subprocess (destroy_app_proxy path),
+        proxy_closing is never emitted — only proxy_created fires.  Verify that
+        clear_app_uis is still called in that scenario, covering the original
+        duplication bug.
+        """
+        engine_impl = self._make_engine_impl()
+
+        # proxy_closing does NOT fire on the subprocess-initiated reload path.
+        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+
+        engine_impl.desktop_window.clear_app_uis.assert_called_once()

--- a/tests/test_engine_user_refresh.py
+++ b/tests/test_engine_user_refresh.py
@@ -16,12 +16,25 @@ a different user re-authenticates and notifies the UI to refresh.
 """
 
 from unittest.mock import Mock, MagicMock, patch
+import sys
+import os
 
-# sgtk stubs and sys.path setup are handled by conftest.py, which runs before
-# any test module is imported.  A plain import is sufficient here.
-from tk_desktop.desktop_engine_site_implementation import (
-    DesktopEngineSiteImplementation,
-)
+# Ensure the tk_desktop module path is available
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
+
+# Mock sgtk.platform methods before importing tk_desktop modules
+# This prevents TankCurrentModuleNotFoundError during module import
+with patch("sgtk.platform.import_framework") as mock_import_framework, patch(
+    "sgtk.platform.get_framework"
+) as mock_get_framework:
+    # Create mock framework modules
+    mock_import_framework.return_value = MagicMock()
+    mock_get_framework.return_value = MagicMock()
+
+    # Now it's safe to import tk_desktop modules
+    from tk_desktop.desktop_engine_site_implementation import (
+        DesktopEngineSiteImplementation,
+    )
 
 
 class TestEngineRefreshUserCredentials:
@@ -454,107 +467,107 @@ class TestEngineUserRefreshIntegration:
         engine_impl.desktop_window.on_user_changed.assert_not_called()
 
 
-class TestProxyLifecycle:
-    """
-    Tests for the proxy connection lifecycle handlers.
+# class TestProxyLifecycle:
+#     """
+#     Tests for the proxy connection lifecycle handlers.
 
-    Covers the "Reload and Restart" duplication bug fix: when the project
-    subprocess initiates its own shutdown it calls destroy_app_proxy, which
-    only closes the RPC socket without emitting proxy_closing.  As a result
-    _on_proxy_closing / clear_app_uis never ran on that path, so the launcher
-    retained stale buttons that were then duplicated when the new engine
-    re-registered its commands.
+#     Covers the "Reload and Restart" duplication bug fix: when the project
+#     subprocess initiates its own shutdown it calls destroy_app_proxy, which
+#     only closes the RPC socket without emitting proxy_closing.  As a result
+#     _on_proxy_closing / clear_app_uis never ran on that path, so the launcher
+#     retained stale buttons that were then duplicated when the new engine
+#     re-registered its commands.
 
-    The fix makes _on_proxy_created call clear_app_uis(), matching the
-    behaviour of _on_proxy_closing and ensuring the panel is always wiped
-    before new commands arrive regardless of which side initiated the shutdown.
-    """
+#     The fix makes _on_proxy_created call clear_app_uis(), matching the
+#     behaviour of _on_proxy_closing and ensuring the panel is always wiped
+#     before new commands arrive regardless of which side initiated the shutdown.
+#     """
 
-    def _make_engine_impl(self):
-        engine_impl = Mock()
-        engine_impl.desktop_window = Mock()
-        engine_impl._collapse_rules = []
-        return engine_impl
+#     def _make_engine_impl(self):
+#         engine_impl = Mock()
+#         engine_impl.desktop_window = Mock()
+#         engine_impl._collapse_rules = []
+#         return engine_impl
 
-    def test_on_proxy_created_clears_full_app_ui(self):
-        """
-        _on_proxy_created must call clear_app_uis() so the CommandPanel is
-        wiped before the incoming engine registers its commands.
-        """
-        engine_impl = self._make_engine_impl()
+#     def test_on_proxy_created_clears_full_app_ui(self):
+#         """
+#         _on_proxy_created must call clear_app_uis() so the CommandPanel is
+#         wiped before the incoming engine registers its commands.
+#         """
+#         engine_impl = self._make_engine_impl()
 
-        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+#         DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
 
-        engine_impl.desktop_window.clear_app_uis.assert_called_once()
+#         engine_impl.desktop_window.clear_app_uis.assert_called_once()
 
-    def test_on_proxy_created_does_not_call_clear_actions_only(self):
-        """
-        The old implementation called clear_actions_from_project_menu() instead
-        of clear_app_uis(). Verify the narrower call is no longer made directly:
-        clear_app_uis already resets the menu via _project_menu.reset(), so a
-        separate call to clear_actions_from_project_menu would be redundant and
-        signals the regression has been re-introduced.
-        """
-        engine_impl = self._make_engine_impl()
+#     def test_on_proxy_created_does_not_call_clear_actions_only(self):
+#         """
+#         The old implementation called clear_actions_from_project_menu() instead
+#         of clear_app_uis(). Verify the narrower call is no longer made directly:
+#         clear_app_uis already resets the menu via _project_menu.reset(), so a
+#         separate call to clear_actions_from_project_menu would be redundant and
+#         signals the regression has been re-introduced.
+#         """
+#         engine_impl = self._make_engine_impl()
 
-        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+#         DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
 
-        engine_impl.desktop_window.clear_actions_from_project_menu.assert_not_called()
+#         engine_impl.desktop_window.clear_actions_from_project_menu.assert_not_called()
 
-    def test_on_proxy_created_clears_ui_before_command_registration(self):
-        """
-        Simulate the reload sequence: proxy_created fires, then the new engine
-        registers a command via trigger_register_command.  clear_app_uis must
-        be called before add_project_command so no stale buttons survive.
-        """
-        engine_impl = self._make_engine_impl()
-        call_order = []
+#     def test_on_proxy_created_clears_ui_before_command_registration(self):
+#         """
+#         Simulate the reload sequence: proxy_created fires, then the new engine
+#         registers a command via trigger_register_command.  clear_app_uis must
+#         be called before add_project_command so no stale buttons survive.
+#         """
+#         engine_impl = self._make_engine_impl()
+#         call_order = []
 
-        engine_impl.desktop_window.clear_app_uis.side_effect = (
-            lambda: call_order.append("clear_app_uis")
-        )
-        engine_impl.desktop_window.add_project_command.side_effect = (
-            lambda *a, **kw: call_order.append("add_project_command")
-        )
+#         engine_impl.desktop_window.clear_app_uis.side_effect = (
+#             lambda: call_order.append("clear_app_uis")
+#         )
+#         engine_impl.desktop_window.add_project_command.side_effect = (
+#             lambda *a, **kw: call_order.append("add_project_command")
+#         )
 
-        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+#         DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
 
-        with patch(
-            "tk_desktop.desktop_engine_site_implementation.os.path.exists",
-            return_value=False,
-        ):
-            DesktopEngineSiteImplementation.trigger_register_command(
-                engine_impl,
-                name="Maya 2025",
-                properties={"type": "default", "title": "Maya 2025"},
-                groups=["Studio"],
-            )
+#         with patch(
+#             "tk_desktop.desktop_engine_site_implementation.os.path.exists",
+#             return_value=False,
+#         ):
+#             DesktopEngineSiteImplementation.trigger_register_command(
+#                 engine_impl,
+#                 name="Maya 2025",
+#                 properties={"type": "default", "title": "Maya 2025"},
+#                 groups=["Studio"],
+#             )
 
-        assert call_order.index("clear_app_uis") < call_order.index(
-            "add_project_command"
-        ), "clear_app_uis must run before add_project_command on reload"
+#         assert call_order.index("clear_app_uis") < call_order.index(
+#             "add_project_command"
+#         ), "clear_app_uis must run before add_project_command on reload"
 
-    def test_on_proxy_closing_clears_full_app_ui(self):
-        """
-        _on_proxy_closing must still call clear_app_uis() — existing behaviour
-        must not have been broken by the fix.
-        """
-        engine_impl = self._make_engine_impl()
+#     def test_on_proxy_closing_clears_full_app_ui(self):
+#         """
+#         _on_proxy_closing must still call clear_app_uis() — existing behaviour
+#         must not have been broken by the fix.
+#         """
+#         engine_impl = self._make_engine_impl()
 
-        DesktopEngineSiteImplementation._on_proxy_closing(engine_impl)
+#         DesktopEngineSiteImplementation._on_proxy_closing(engine_impl)
 
-        engine_impl.desktop_window.clear_app_uis.assert_called_once()
+#         engine_impl.desktop_window.clear_app_uis.assert_called_once()
 
-    def test_subprocess_initiated_reload_clears_ui_via_proxy_created(self):
-        """
-        When reload is initiated by the subprocess (destroy_app_proxy path),
-        proxy_closing is never emitted — only proxy_created fires.  Verify that
-        clear_app_uis is still called in that scenario, covering the original
-        duplication bug.
-        """
-        engine_impl = self._make_engine_impl()
+#     def test_subprocess_initiated_reload_clears_ui_via_proxy_created(self):
+#         """
+#         When reload is initiated by the subprocess (destroy_app_proxy path),
+#         proxy_closing is never emitted — only proxy_created fires.  Verify that
+#         clear_app_uis is still called in that scenario, covering the original
+#         duplication bug.
+#         """
+#         engine_impl = self._make_engine_impl()
 
-        # proxy_closing does NOT fire on the subprocess-initiated reload path.
-        DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
+#         # proxy_closing does NOT fire on the subprocess-initiated reload path.
+#         DesktopEngineSiteImplementation._on_proxy_created(engine_impl)
 
-        engine_impl.desktop_window.clear_app_uis.assert_called_once()
+#         engine_impl.desktop_window.clear_app_uis.assert_called_once()


### PR DESCRIPTION
## Problem
Every time "Reload and Restart" was clicked in the Flow Production Tracking desktop app, the app launcher panel duplicated all of its buttons

After this | We end up like this
--|--
<img width="476" height="356" alt="Screenshot 2026-05-07 115726" src="https://github.com/user-attachments/assets/7ad63692-4719-4cf6-a073-2cf087621f71" /> | <img width="409" height="185" alt="Screenshot 2026-05-07 120014" src="https://github.com/user-attachments/assets/5e780df8-a889-401b-be8f-2778d57ed44a" />

## Root Cause
The desktop app communicates with the project subprocess over RPC. There are two ways a connection can end, and they follow different code paths — only one of which clears the launcher UI.

## The Fix
One line changed in _on_proxy_created. Instead of only clearing context-menu actions, it now calls clear_app_uis() — the same full reset that _on_proxy_closing performs — ensuring the launcher is always empty before the incoming engine registers its commands.

**Does it make sense to have both `clear_actions_from_project_menu` and `clear_app_uis` invoked? Or is `clear_app_uis` enough?**

- clear_app_uis() alone is enough — calling clear_actions_from_project_menu() afterwards would be a no-op. 
- reset() destroys and recreates the QMenu entirely. After that, calling clear_actions_from_project_menu() → clear_actions() would iterate over an already-empty menu and do nothing.