### PR TITLE
SG-43676 Handle popen and stop processes on application shutdown

### DIFF
--- a/hooks/launch_python.py
+++ b/hooks/launch_python.py
@@ -59,7 +59,12 @@ class LaunchPython(Hook):
         # will be shared with the child process and it prevent restarting the server
         # after the process closes.
         # Solution was found here: http://stackoverflow.com/a/13593715
-        subprocess.Popen(args, startupinfo=startupinfo, close_fds=True)
+        process = subprocess.Popen(args, startupinfo=startupinfo, close_fds=True)
+
+        # Keep track of the bootstrap process so it can be terminated when the
+        # desktop app disconnects from the project or quits.
+        if hasattr(self.parent, "site_comm"):
+            self.parent.site_comm.set_bootstrap_process(process)
 
     def path_to_bootstrap(self):
         """

--- a/hooks/launch_python.py
+++ b/hooks/launch_python.py
@@ -17,10 +17,9 @@ import sys
 import subprocess
 
 import tank
-from tank import Hook
 
 
-class LaunchPython(Hook):
+class LaunchPython(tank.Hook):
     def execute(self, project_python, pickle_data_path, utilities_module_path):
         """
         Launch the python process that will start the project specific tk-desktop

--- a/hooks/launch_python.py
+++ b/hooks/launch_python.py
@@ -59,7 +59,9 @@ class LaunchPython(Hook):
         # will be shared with the child process and it prevent restarting the server
         # after the process closes.
         # Solution was found here: http://stackoverflow.com/a/13593715
-        process = subprocess.Popen(args, startupinfo=startupinfo, close_fds=True)
+        process = subprocess.Popen(
+            args, startupinfo=startupinfo, close_fds=True
+        )  # nosec B603 - args are built from trusted toolkit internals, not user input
 
         # Keep track of the bootstrap process so it can be terminated when the
         # desktop app disconnects from the project or quits.

--- a/hooks/launch_python.py
+++ b/hooks/launch_python.py
@@ -63,8 +63,10 @@ class LaunchPython(Hook):
 
         # Keep track of the bootstrap process so it can be terminated when the
         # desktop app disconnects from the project or quits.
-        if hasattr(self.parent, "site_comm"):
+        try:
             self.parent.site_comm.set_bootstrap_process(process)
+        except AttributeError:
+            pass
 
     def path_to_bootstrap(self):
         """

--- a/python/tk_desktop/bootstrap_process.py
+++ b/python/tk_desktop/bootstrap_process.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Helpers for managing the project bootstrap subprocess launched by tk-desktop.
+"""
+
+import subprocess
+
+from sgtk import LogManager
+
+logger = LogManager.get_logger(__name__)
+
+DEFAULT_TERMINATION_TIMEOUT = 5
+
+
+def terminate_process(process, timeout=DEFAULT_TERMINATION_TIMEOUT):
+    """
+    Terminates a subprocess if it is still running.
+
+    :param process: A :class:`subprocess.Popen` instance, or None.
+    :param timeout: Number of seconds to wait for graceful termination before killing.
+    """
+    if process is None:
+        return
+
+    if process.poll() is not None:
+        return
+
+    logger.debug("Terminating bootstrap process (pid %s)...", process.pid)
+    try:
+        process.terminate()
+    except Exception as exc:
+        logger.warning("Error terminating bootstrap process: %s", exc)
+        return
+
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Bootstrap process (pid %s) did not exit, killing...", process.pid
+        )
+        try:
+            process.kill()
+            process.wait(timeout=timeout)
+        except Exception as exc:
+            logger.warning("Error killing bootstrap process: %s", exc)

--- a/python/tk_desktop/bootstrap_process.py
+++ b/python/tk_desktop/bootstrap_process.py
@@ -12,7 +12,7 @@
 Helpers for managing the project bootstrap subprocess launched by tk-desktop.
 """
 
-import subprocess
+import subprocess  # nosec B404
 from typing import Optional
 
 from sgtk import LogManager

--- a/python/tk_desktop/bootstrap_process.py
+++ b/python/tk_desktop/bootstrap_process.py
@@ -13,17 +13,17 @@ Helpers for managing the project bootstrap subprocess launched by tk-desktop.
 """
 
 import subprocess  # nosec B404
-from typing import Optional
+import typing
 
-from sgtk import LogManager
+import sgtk
 
-logger = LogManager.get_logger(__name__)
+logger = sgtk.LogManager.get_logger(__name__)
 
 DEFAULT_TERMINATION_TIMEOUT: int = 5
 
 
 def terminate_process(
-    process: Optional[subprocess.Popen],
+    process: typing.Optional[subprocess.Popen],
     timeout: int = DEFAULT_TERMINATION_TIMEOUT,
 ) -> None:
     """

--- a/python/tk_desktop/bootstrap_process.py
+++ b/python/tk_desktop/bootstrap_process.py
@@ -13,15 +13,19 @@ Helpers for managing the project bootstrap subprocess launched by tk-desktop.
 """
 
 import subprocess
+from typing import Optional
 
 from sgtk import LogManager
 
 logger = LogManager.get_logger(__name__)
 
-DEFAULT_TERMINATION_TIMEOUT = 5
+DEFAULT_TERMINATION_TIMEOUT: int = 5
 
 
-def terminate_process(process, timeout=DEFAULT_TERMINATION_TIMEOUT):
+def terminate_process(
+    process: Optional[subprocess.Popen],
+    timeout: int = DEFAULT_TERMINATION_TIMEOUT,
+) -> None:
     """
     Terminates a subprocess if it is still running.
 

--- a/python/tk_desktop/bootstrap_process.py
+++ b/python/tk_desktop/bootstrap_process.py
@@ -41,18 +41,26 @@ def terminate_process(
     logger.debug("Terminating bootstrap process (pid %s)...", process.pid)
     try:
         process.terminate()
-    except Exception as exc:
+    except OSError as exc:
         logger.warning("Error terminating bootstrap process: %s", exc)
+
+    try:
+        process.wait(timeout=timeout)
         return
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Bootstrap process (pid %s) did not exit after terminate(), killing...",
+            process.pid,
+        )
+
+    try:
+        process.kill()
+    except OSError as exc:
+        logger.warning("Error killing bootstrap process: %s", exc)
 
     try:
         process.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         logger.warning(
-            "Bootstrap process (pid %s) did not exit, killing...", process.pid
+            "Bootstrap process (pid %s) did not exit after kill().", process.pid
         )
-        try:
-            process.kill()
-            process.wait(timeout=timeout)
-        except Exception as exc:
-            logger.warning("Error killing bootstrap process: %s", exc)

--- a/python/tk_desktop/site_communication.py
+++ b/python/tk_desktop/site_communication.py
@@ -12,6 +12,8 @@
 Implements communication channels between the desktop app and the background process.
 """
 
+import subprocess
+
 from sgtk.platform.qt import QtCore
 from .bootstrap_process import terminate_process
 from .communication_base import CommunicationBase
@@ -34,7 +36,7 @@ class SiteCommunication(QtCore.QObject, CommunicationBase):
         QtCore.QObject.__init__(self)
         self._bootstrap_process = None
 
-    def set_bootstrap_process(self, process):
+    def set_bootstrap_process(self, process: subprocess.Popen) -> None:
         """
         Registers the bootstrap subprocess and terminates any previous one.
 
@@ -43,7 +45,7 @@ class SiteCommunication(QtCore.QObject, CommunicationBase):
         self._terminate_bootstrap_process()
         self._bootstrap_process = process
 
-    def _terminate_bootstrap_process(self):
+    def _terminate_bootstrap_process(self) -> None:
         """
         Terminates the bootstrap subprocess if one is still running.
         """
@@ -51,9 +53,16 @@ class SiteCommunication(QtCore.QObject, CommunicationBase):
         self._bootstrap_process = None
         terminate_process(process)
 
-    def shut_down(self):
+    def shut_down(self) -> None:
         """
-        Disconnects from the project proxy and terminates the bootstrap subprocess.
+        Overrides :meth:`CommunicationBase.shut_down` to also terminate the
+        bootstrap subprocess after disconnecting from the RPC proxy.
+
+        Called from the following locations:
+        - ``desktop_window._about_to_quit``: user quits Desktop via menu / Alt+F4
+        - ``desktop_window._on_back_to_projects_clicked``: user returns to the project browser
+        - ``desktop_window.__launch_app_proxy_for_project``: before switching to a new project
+        - ``desktop_engine_site_implementation.destroy_engine``: engine teardown
         """
         CommunicationBase.shut_down(self)
         self._terminate_bootstrap_process()

--- a/python/tk_desktop/site_communication.py
+++ b/python/tk_desktop/site_communication.py
@@ -13,6 +13,7 @@ Implements communication channels between the desktop app and the background pro
 """
 
 from sgtk.platform.qt import QtCore
+from .bootstrap_process import terminate_process
 from .communication_base import CommunicationBase
 
 from sgtk import LogManager
@@ -31,6 +32,31 @@ class SiteCommunication(QtCore.QObject, CommunicationBase):
     def __init__(self):
         CommunicationBase.__init__(self)
         QtCore.QObject.__init__(self)
+        self._bootstrap_process = None
+
+    def set_bootstrap_process(self, process):
+        """
+        Registers the bootstrap subprocess and terminates any previous one.
+
+        :param process: A :class:`subprocess.Popen` instance for the bootstrap process.
+        """
+        self._terminate_bootstrap_process()
+        self._bootstrap_process = process
+
+    def _terminate_bootstrap_process(self):
+        """
+        Terminates the bootstrap subprocess if one is still running.
+        """
+        process = self._bootstrap_process
+        self._bootstrap_process = None
+        terminate_process(process)
+
+    def shut_down(self):
+        """
+        Disconnects from the project proxy and terminates the bootstrap subprocess.
+        """
+        CommunicationBase.shut_down(self)
+        self._terminate_bootstrap_process()
 
     def _create_proxy(self, pipe, authkey):
         """

--- a/python/tk_desktop/site_communication.py
+++ b/python/tk_desktop/site_communication.py
@@ -64,7 +64,7 @@ class SiteCommunication(
         - ``desktop_window.__launch_app_proxy_for_project``: before switching to a new project
         - ``desktop_engine_site_implementation.destroy_engine``: engine teardown
         """
-        super().shut_down()
+        CommunicationBase.shut_down(self)
         self._terminate_bootstrap_process()
 
     def _create_proxy(self, pipe, authkey):

--- a/python/tk_desktop/site_communication.py
+++ b/python/tk_desktop/site_communication.py
@@ -64,7 +64,7 @@ class SiteCommunication(QtCore.QObject, CommunicationBase):
         - ``desktop_window.__launch_app_proxy_for_project``: before switching to a new project
         - ``desktop_engine_site_implementation.destroy_engine``: engine teardown
         """
-        CommunicationBase.shut_down(self)
+        super().shut_down()
         self._terminate_bootstrap_process()
 
     def _create_proxy(self, pipe, authkey):

--- a/python/tk_desktop/site_communication.py
+++ b/python/tk_desktop/site_communication.py
@@ -14,26 +14,26 @@ Implements communication channels between the desktop app and the background pro
 
 import subprocess
 
-from sgtk.platform.qt import QtCore
-from .bootstrap_process import terminate_process
-from .communication_base import CommunicationBase
+import sgtk
+from . import bootstrap_process
+from . import communication_base
 
-from sgtk import LogManager
-
-logger = LogManager.get_logger(__name__)
+logger = sgtk.LogManager.get_logger(__name__)
 
 
-class SiteCommunication(QtCore.QObject, CommunicationBase):
+class SiteCommunication(
+    sgtk.platform.qt.QtCore.QObject, communication_base.CommunicationBase
+):
     """
     Communication channel for the site engine to the project engine.
     """
 
-    proxy_closing = QtCore.Signal()
-    proxy_created = QtCore.Signal()
+    proxy_closing = sgtk.platform.qt.QtCore.Signal()
+    proxy_created = sgtk.platform.qt.QtCore.Signal()
 
     def __init__(self):
-        CommunicationBase.__init__(self)
-        QtCore.QObject.__init__(self)
+        communication_base.CommunicationBase.__init__(self)
+        sgtk.platform.qt.QtCore.QObject.__init__(self)
         self._bootstrap_process = None
 
     def set_bootstrap_process(self, process: subprocess.Popen) -> None:
@@ -51,7 +51,7 @@ class SiteCommunication(QtCore.QObject, CommunicationBase):
         """
         process = self._bootstrap_process
         self._bootstrap_process = None
-        terminate_process(process)
+        bootstrap_process.terminate_process(process)
 
     def shut_down(self) -> None:
         """
@@ -71,7 +71,7 @@ class SiteCommunication(QtCore.QObject, CommunicationBase):
         """
         Connects to the other process's RPC server.
         """
-        CommunicationBase._create_proxy(self, pipe, authkey)
+        communication_base.CommunicationBase._create_proxy(self, pipe, authkey)
         self.proxy_created.emit()
 
     def start_server(self):

--- a/tests/test_bootstrap_process.py
+++ b/tests/test_bootstrap_process.py
@@ -25,7 +25,9 @@ with unittest.mock.patch.dict(
         )
     },
 ):
-    from tk_desktop.bootstrap_process import terminate_process
+    import tk_desktop.bootstrap_process
+
+terminate_process = tk_desktop.bootstrap_process.terminate_process
 
 
 class TestTerminateProcess:

--- a/tests/test_bootstrap_process.py
+++ b/tests/test_bootstrap_process.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import subprocess
+import sys
+import os
+from unittest.mock import Mock, MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
+
+with patch.dict(
+    "sys.modules",
+    {"sgtk": MagicMock(LogManager=MagicMock(get_logger=MagicMock(return_value=Mock())))},
+):
+    from tk_desktop.bootstrap_process import terminate_process
+
+
+class TestTerminateProcess:
+    def test_does_nothing_when_process_is_none(self):
+        terminate_process(None)
+
+    def test_does_nothing_when_process_already_exited(self):
+        process = Mock()
+        process.poll.return_value = 0
+
+        terminate_process(process)
+
+        process.terminate.assert_not_called()
+        process.kill.assert_not_called()
+
+    def test_terminates_running_process(self):
+        process = Mock()
+        process.poll.return_value = None
+        process.pid = 1234
+        process.wait.return_value = 0
+
+        terminate_process(process)
+
+        process.terminate.assert_called_once_with()
+        process.wait.assert_called_once_with(timeout=5)
+        process.kill.assert_not_called()
+
+    def test_kills_process_when_terminate_times_out(self):
+        process = Mock()
+        process.poll.return_value = None
+        process.pid = 1234
+        process.wait.side_effect = [subprocess.TimeoutExpired("cmd", 5), 0]
+
+        terminate_process(process)
+
+        process.terminate.assert_called_once_with()
+        process.kill.assert_called_once_with()
+        assert process.wait.call_count == 2

--- a/tests/test_bootstrap_process.py
+++ b/tests/test_bootstrap_process.py
@@ -20,9 +20,7 @@ with unittest.mock.patch.dict(
     {
         "sgtk": unittest.mock.MagicMock(
             LogManager=unittest.mock.MagicMock(
-                get_logger=unittest.mock.MagicMock(
-                    return_value=unittest.mock.Mock()
-                )
+                get_logger=unittest.mock.MagicMock(return_value=unittest.mock.Mock())
             )
         )
     },

--- a/tests/test_bootstrap_process.py
+++ b/tests/test_bootstrap_process.py
@@ -8,16 +8,24 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import os
 import subprocess
 import sys
-import os
-from unittest.mock import Mock, MagicMock, patch
+import unittest.mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
 
-with patch.dict(
+with unittest.mock.patch.dict(
     "sys.modules",
-    {"sgtk": MagicMock(LogManager=MagicMock(get_logger=MagicMock(return_value=Mock())))},
+    {
+        "sgtk": unittest.mock.MagicMock(
+            LogManager=unittest.mock.MagicMock(
+                get_logger=unittest.mock.MagicMock(
+                    return_value=unittest.mock.Mock()
+                )
+            )
+        )
+    },
 ):
     from tk_desktop.bootstrap_process import terminate_process
 
@@ -27,7 +35,7 @@ class TestTerminateProcess:
         terminate_process(None)
 
     def test_does_nothing_when_process_already_exited(self):
-        process = Mock()
+        process = unittest.mock.Mock()
         process.poll.return_value = 0
 
         terminate_process(process)
@@ -36,7 +44,7 @@ class TestTerminateProcess:
         process.kill.assert_not_called()
 
     def test_terminates_running_process(self):
-        process = Mock()
+        process = unittest.mock.Mock()
         process.poll.return_value = None
         process.pid = 1234
         process.wait.return_value = 0
@@ -48,7 +56,7 @@ class TestTerminateProcess:
         process.kill.assert_not_called()
 
     def test_kills_process_when_terminate_times_out(self):
-        process = Mock()
+        process = unittest.mock.Mock()
         process.poll.return_value = None
         process.pid = 1234
         process.wait.side_effect = [subprocess.TimeoutExpired("cmd", 5), 0]


### PR DESCRIPTION
**Problem**
The bootstrap python.exe process spawned when opening a project was never terminated when Desktop quit, leaving orphan processes that locked Toolkit cache files, preventing tk-core to refresh the cache when needed.

**Change**

- Track the bootstrap Popen handle when Desktop opens a project (launch_python hook) instead of fire-and-forget spawning.
- Terminate the bootstrap subprocess on existing shutdown paths (site_comm.shut_down()): Quit Desktop, back to projects, switch project, and engine destroy.
- Add terminate_process() helper with graceful terminate() → kill() fallback, plus unit tests for the termination logic.
- Fixes orphan Shotgun\Python3\python.exe processes that could survive after Desktop quit and lock Toolkit cache files (e.g. pkgs.zip), blocking manual cache cleanup and config refresh.

Note: Closing the dialog to the system tray is unchanged — the subprocess remains running while a project is active in the background.

Testing Done:

- Open Desktop → open a project → confirm apps load normally
- Confirm bootstrap python.exe is running (bootstrap.py in command
- Quit Desktop fully → confirm bootstrap process is gone
- Repeat open/quit 3–5 times → confirm no accumulating orphan processes
- Open project → close dialog to tray → confirm bootstrap still running → reopen from tray → project still works
- Back to projects → confirm bootstrap process is gone
- After quit, confirm cache folder is not locked by orphan processes
- Make sure only one python.exe shotgun process is active at all time.